### PR TITLE
perf(docker): optimize backend docker image

### DIFF
--- a/chatbot-core/Makefile
+++ b/chatbot-core/Makefile
@@ -45,7 +45,7 @@ start:  ## Start stopped services
 
 clean:  ## Stop services and remove containers and volumes
 	@echo "Services and volumes have been removed..."
-	@$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) -p chatbot-core down v
+	@$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) -p chatbot-core down -v
 
 help:  ## Show this help
 	@echo "Available commands:"

--- a/chatbot-core/backend/Dockerfile
+++ b/chatbot-core/backend/Dockerfile
@@ -28,9 +28,10 @@ WORKDIR /app
 
 # Install uv and dependencies
 COPY --from=ghcr.io/astral-sh/uv:0.5.4 /uv /uvx /bin/
-COPY pyproject.toml /app
-COPY uv.lock /app
-RUN uv sync --no-dev --frozen --no-cache --verbose
+RUN --mount=type=cache,target=/root/.cache/uv \
+  --mount=type=bind,source=uv.lock,target=uv.lock \
+  --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+  uv sync --no-dev --frozen --no-install-project --verbose
 
 # Cleanup for CVEs and size reduction
 # https://github.com/tornadoweb/tornado/issues/3107
@@ -54,6 +55,10 @@ RUN apt-get update && \
 
 # Copy the application into the container, including uv.lock
 COPY . /app
+
+# Sync the project
+RUN --mount=type=cache,target=/root/.cache/uv \
+  uv sync --frozen
 
 # Expose the port on which the application will run
 ENV PYTHONPATH=/app

--- a/chatbot-core/backend/Dockerfile
+++ b/chatbot-core/backend/Dockerfile
@@ -8,34 +8,55 @@ FROM python:3.11.10-slim-bookworm
 LABEL org.opencontainers.image.source "https://github.com/TinhHoaSolutions-EzHR/chatbot"
 LABEL org.opencontainers.image.descripiton "Docker image for backend api_server"
 
-# Install required system packages and Microsoft ODBC Driver for SQL Server
+# Set this to avoid buffering stdout and stderr
+ENV PYTHONUNBUFFERED=1
+
+# Install required system packages, Microsoft ODBC Driver for SQL Server
 RUN apt-get update && apt-get install -y --no-install-recommends \
   curl=7.88.1-10+deb12u8 \
+  ca-certificates=20230311 \
   unixodbc=2.3.11-2+deb12u1 \
   odbcinst=2.3.11-2+deb12u1 && \
   curl -sSL https://packages.microsoft.com/debian/12/prod/pool/main/m/msodbcsql17/msodbcsql17_17.10.6.1-1_amd64.deb -o msodbcsql17_17.10.6.1-1_amd64.deb && \
   ACCEPT_EULA=Y dpkg --install ./msodbcsql17_17.10.6.1-1_amd64.deb && \
   rm ./msodbcsql17_17.10.6.1-1_amd64.deb && \
-  apt-get clean && \
-  apt-get autoremove -y && \
-  rm -rf /var/lib/apt/lists/*
-
-# Set this to avoid buffering stdout and stderr
-ENV PYTHONUNBUFFERED=1
-
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
-# Copy the application into the container, including uv.lock
-COPY . /app
+  rm -rf /var/lib/apt/lists/* && \
+  apt-get clean
 
 # Set the working directory in the container
 WORKDIR /app
 
-# Install dependencies
-RUN uv sync --frozen --no-cache
+# Install uv and dependencies
+COPY --from=ghcr.io/astral-sh/uv:0.5.4 /uv /uvx /bin/
+COPY pyproject.toml /app
+COPY uv.lock /app
+RUN uv sync --no-dev --frozen --no-cache --verbose
+
+# Cleanup for CVEs and size reduction
+# https://github.com/tornadoweb/tornado/issues/3107
+# xserver-common and xvfb included by playwright installation but not needed after
+# perl-base is part of the base Python Debian image but not needed for Danswer functionality
+# perl-base could only be removed with --allow-remove-essential
+RUN apt-get update && \
+  apt-get remove -y --allow-remove-essential \
+  perl-base \
+  xserver-common \
+  xvfb \
+  cmake \
+  libldap-2.5-0 \
+  libxmlsec1-dev \
+  pkg-config \
+  gcc && \
+  apt-get install -y libxmlsec1-openssl && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -f /usr/local/lib/python3.11/site-packages/tornado/test/test.key
+
+# Copy the application into the container, including uv.lock
+COPY . /app
 
 # Expose the port on which the application will run
+ENV PYTHONPATH=/app
 EXPOSE 5000
 
 # Default command which does nothing


### PR DESCRIPTION
## Description

Optimize backend's docker image
- Optimize layer caching
- Image size: 607.74MB
- Image build time reduced from 10 seconds to 1-3 seconds

## How Has This Been Tested?

Test manually under local.

## Related Issue(s)

Issue #35 

## Checklist:

- [x] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [x] Author has done a final read through of the PR right before merge
