### PR TITLE
feat(backend): add user settings update feature

### DIFF
--- a/chatbot-core/EzHR-Chatbot.dbml
+++ b/chatbot-core/EzHR-Chatbot.dbml
@@ -27,6 +27,7 @@ Project "EzHR-Chatbot" {
 11. document_metadata_tag: Tags for documents
 12. llm_provider: LLM service configurations
 13. embedding_provider: Embedding service configurations
+14. user_setting: User-specific settings
 
 ### Key Relationships:
 1. agent -> prompt: One-to-one (system prompt)
@@ -36,6 +37,7 @@ Project "EzHR-Chatbot" {
 5. feedback -> chat_message: Many-to-one
 6. document_metadata_tag -> document_metadata: Many-to-one
 7. agent_tool: Many-to-many between agents and tools
+8. user_setting -> user: One-to-one
 '''
 }
 
@@ -108,8 +110,22 @@ TABLE chatbot_core.user {
   is_admin boolean [not null, default: false, note: 'Whether user is admin or not.']
   is_verified boolean [not null, default: false, note: 'Whether user is verified via email or not.']
   role user_role [not null, note: 'Role of the user. E.g. admin, user.']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
 
   Note: 'User table to store basic user details.'
+}
+
+TABLE chatbot_core.user_setting {
+  id uuid [unique, not null, primary key]
+  recent_agent_id uuid [null, ref: > chatbot_core.agent.id, note: 'Recent agent id used by the user.']
+  auto_scroll boolean [not null, default: true, note: 'Whether auto scroll is enabled or not.']
+  created_at timestamp
+  updated_at timestamp
+  deleted_at timestamp
+
+  Note: 'Table to store user settings.'
 }
 
 TABLE chatbot_core.agent {

--- a/chatbot-core/backend/app/main.py
+++ b/chatbot-core/backend/app/main.py
@@ -8,7 +8,11 @@ from app.databases.redis import RedisConnector
 from app.routers import base
 from app.routers.v1 import chat
 from app.routers.v1 import connector
+<<<<<<< HEAD
 from app.routers.v1 import folder
+=======
+from app.routers.v1 import user
+>>>>>>> 34c25bb (fix(backend): bug not declare router and type of list to save in db)
 from app.settings import Constants
 from app.utils.api.helpers import get_logger
 from app.utils.llm.helpers import init_llm_configurations
@@ -68,6 +72,7 @@ def create_app() -> FastAPI:
     app.include_router(router=connector.router, prefix=Constants.FASTAPI_PREFIX)
     app.include_router(router=chat.router, prefix=Constants.FASTAPI_PREFIX)
     app.include_router(router=folder.router, prefix=Constants.FASTAPI_PREFIX)
+    app.include_router(router=user.router, prefix=Constants.FASTAPI_PREFIX)
 
     return app
 

--- a/chatbot-core/backend/app/main.py
+++ b/chatbot-core/backend/app/main.py
@@ -8,11 +8,8 @@ from app.databases.redis import RedisConnector
 from app.routers import base
 from app.routers.v1 import chat
 from app.routers.v1 import connector
-<<<<<<< HEAD
 from app.routers.v1 import folder
-=======
 from app.routers.v1 import user
->>>>>>> 34c25bb (fix(backend): bug not declare router and type of list to save in db)
 from app.settings import Constants
 from app.utils.api.helpers import get_logger
 from app.utils.llm.helpers import init_llm_configurations

--- a/chatbot-core/backend/app/models/__init__.py
+++ b/chatbot-core/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.chat import ChatFeedback
 from app.models.folder import Folder
 from app.models.prompt import Prompt
 from app.models.user import User
+from app.models.user import UserSetting
 
 __all__ = [
     "Agent",
@@ -14,4 +15,5 @@ __all__ = [
     "Prompt",
     "User",
     "Folder",
+    "UserSetting",
 ]

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -72,6 +72,7 @@ class UserSetting(Base):
     )
     recent_agent_ids: Mapped[str] = mapped_column(String, default="")
     auto_scroll: Mapped[bool] = mapped_column(Boolean, default=True)
+    default_model: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -98,6 +99,7 @@ class UserSettingRequest(BaseModel):
 
     current_agent_id: Optional[UUID] = Field(None, title="Current using agent ID")
     auto_scroll: bool = Field(True, title="Auto scroll chat messages")
+    default_model: Optional[str] = Field(None, title="Default model for the user")
 
     class Config:
         from_attributes = True

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timezone
 from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -9,11 +11,14 @@ from uuid import uuid4
 from pydantic import BaseModel
 from pydantic import Field
 from sqlalchemy import Boolean
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
 from sqlalchemy import String
 from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 
 from app.models.base import Base
 
@@ -32,14 +37,57 @@ class User(Base):
     __table_args__ = {"extend_existing": True}
 
     id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
-        UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, index=True, default=uuid4
+        UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, default=uuid4
     )
-    recent_agent_ids: Mapped[str] = mapped_column(String, default="")
-    auto_scroll: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
 
     # Define relationships. We use the type hinting string to avoid circular imports.
     chat_sessions: Mapped[List["ChatSession"]] = relationship("ChatSession", back_populates="user")
     folders: Mapped[List["Folder"]] = relationship("Folder", back_populates="user")
+    user_setting: Mapped["UserSetting"] = relationship("UserSetting", back_populates="user")
+
+
+class UserSetting(Base):
+    """
+    Represents the user settings in the chatbot system.
+    Tracks the settings for each user.
+    """
+
+    __tablename__ = "user_setting"
+
+    id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), primary_key=True
+    )
+    recent_agent_ids: Mapped[str] = mapped_column(String, default="")
+    auto_scroll: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    # Define relationships.
+    user: Mapped["User"] = relationship("User", back_populates="user_setting")
 
 
 class UserSettingRequest(BaseModel):

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from pydantic import BaseModel
 from pydantic import Field
 from sqlalchemy import Boolean
+from sqlalchemy import String
 from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
@@ -33,7 +34,7 @@ class User(Base):
     id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
         UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, index=True, default=uuid4
     )
-    recent_agent_ids: Mapped[str] = mapped_column(str, default_factory=str)
+    recent_agent_ids: Mapped[str] = mapped_column(String, default="")
     auto_scroll: Mapped[bool] = mapped_column(Boolean, default=True)
 
     # Define relationships. We use the type hinting string to avoid circular imports.

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from typing import List
+from typing import Optional
 from typing import TYPE_CHECKING
+from uuid import UUID
 from uuid import uuid4
 
+from pydantic import BaseModel
+from pydantic import Field
 from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
@@ -28,6 +32,20 @@ class User(Base):
     id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
         UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, index=True, default=uuid4
     )
+    recent_agent_ids: Mapped[str] = mapped_column(str, default_factory=str)
 
     chat_sessions: Mapped[List["ChatSession"]] = relationship("ChatSession", back_populates="user")
     folders: Mapped[List["Folder"]] = relationship("Folder", back_populates="user")
+
+
+class UserSettingRequest(BaseModel):
+    """
+    Pydantic model for user settings request.
+    Defines the fields that can be updated in the user settings.
+    """
+
+    current_agent_id: Optional[UUID] = Field(None, title="Current using agent ID")
+
+    class Config:
+        from_attributes = True
+        arbitrary_types_allowed = True

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 from pydantic import Field
+from sqlalchemy import Boolean
 from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
@@ -33,7 +34,9 @@ class User(Base):
         UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, index=True, default=uuid4
     )
     recent_agent_ids: Mapped[str] = mapped_column(str, default_factory=str)
+    auto_scroll: Mapped[bool] = mapped_column(Boolean, default=True)
 
+    # Define relationships. We use the type hinting string to avoid circular imports.
     chat_sessions: Mapped[List["ChatSession"]] = relationship("ChatSession", back_populates="user")
     folders: Mapped[List["Folder"]] = relationship("Folder", back_populates="user")
 
@@ -45,6 +48,7 @@ class UserSettingRequest(BaseModel):
     """
 
     current_agent_id: Optional[UUID] = Field(None, title="Current using agent ID")
+    auto_scroll: bool = Field(True, title="Auto scroll chat messages")
 
     class Config:
         from_attributes = True

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -52,4 +52,3 @@ class UserSettingRequest(BaseModel):
 
     class Config:
         from_attributes = True
-        arbitrary_types_allowed = True

--- a/chatbot-core/backend/app/repositories/user.py
+++ b/chatbot-core/backend/app/repositories/user.py
@@ -51,7 +51,7 @@ class UserSettingRepository(BaseRepository):
         """
         super().__init__(db_session=db_session)
 
-    def get_user_setting(self, user_id: str) -> Tuple[UserSetting, Optional[APIError]]:
+    def get_user_settings(self, user_id: str) -> Tuple[UserSetting, Optional[APIError]]:
         """
         Get user settings by user ID.
 
@@ -67,10 +67,10 @@ class UserSettingRepository(BaseRepository):
             )
             return user_setting, None
         except Exception as e:
-            logger.error(f"Error getting user setting: {e}")
+            logger.error(f"Error getting user settings: {e}")
             return None, APIError(kind=ErrorCodesMappingNumber.INTERNAL_SERVER_ERROR.value)
 
-    def update_user_setting(self, user_id: str, user_setting: UserSetting) -> Optional[APIError]:
+    def update_user_settings(self, user_id: str, user_settings: UserSetting) -> Optional[APIError]:
         """
         Update user settings.
 
@@ -81,13 +81,8 @@ class UserSettingRepository(BaseRepository):
             Optional[APIError]: API error response
         """
         try:
-            user_setting = {
-                key: value
-                for key, value in user_setting.__dict__.items()
-                if not key.startswith("_")
-            }
             self._db_session.query(UserSetting).filter(UserSetting.id == user_id).update(
-                user_setting
+                user_settings
             )
             return None
         except Exception as e:

--- a/chatbot-core/backend/app/repositories/user.py
+++ b/chatbot-core/backend/app/repositories/user.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from typing import Tuple
 
 from sqlalchemy.orm import Session
 
@@ -20,6 +21,23 @@ class UserRepository(BaseRepository):
             db_session (Session): Database session
         """
         super().__init__(db_session=db_session)
+
+    def get_user(self, user_id: str) -> Tuple[User, Optional[APIError]]:
+        """
+        Get user by id.
+
+        Args:
+            user_id (str): User ID
+
+        Returns:
+            Tuple[User, Optional[APIError]]: User object and API error response
+        """
+        try:
+            user = self._db_session.query(User).filter(User.id == user_id).first()
+            return user, None
+        except Exception as e:
+            logger.error(f"Error getting user: {e}")
+            return None, APIError(kind=ErrorCodesMappingNumber.INTERNAL_SERVER_ERROR.value)
 
     def update_user(self, user_id: str, user: User) -> Optional[APIError]:
         """

--- a/chatbot-core/backend/app/repositories/user.py
+++ b/chatbot-core/backend/app/repositories/user.py
@@ -4,6 +4,7 @@ from typing import Tuple
 from sqlalchemy.orm import Session
 
 from app.models import User
+from app.models import UserSetting
 from app.repositories.base import BaseRepository
 from app.utils.api.api_response import APIError
 from app.utils.api.error_handler import ErrorCodesMappingNumber
@@ -39,19 +40,55 @@ class UserRepository(BaseRepository):
             logger.error(f"Error getting user: {e}")
             return None, APIError(kind=ErrorCodesMappingNumber.INTERNAL_SERVER_ERROR.value)
 
-    def update_user(self, user_id: str, user: User) -> Optional[APIError]:
+
+class UserSettingRepository(BaseRepository):
+    def __init__(self, db_session: Session):
         """
-        Update user.
+        User setting repository class for handling user setting-related database operations.
 
         Args:
-            user (User): User object
+            db_session (Session): Database session
+        """
+        super().__init__(db_session=db_session)
+
+    def get_user_setting(self, user_id: str) -> Tuple[UserSetting, Optional[APIError]]:
+        """
+        Get user settings by user ID.
+
+        Args:
+            user_id (str): User ID
+
+        Returns:
+            Tuple[UserSetting, Optional[APIError]]: User setting object and API error response
+        """
+        try:
+            user_setting = (
+                self._db_session.query(UserSetting).filter(UserSetting.id == user_id).first()
+            )
+            return user_setting, None
+        except Exception as e:
+            logger.error(f"Error getting user setting: {e}")
+            return None, APIError(kind=ErrorCodesMappingNumber.INTERNAL_SERVER_ERROR.value)
+
+    def update_user_setting(self, user_id: str, user_setting: UserSetting) -> Optional[APIError]:
+        """
+        Update user settings.
+
+        Args:
+            user_setting (UserSetting): User setting object
 
         Returns:
             Optional[APIError]: API error response
         """
         try:
-            user = {key: value for key, value in user.__dict__.items() if not key.startswith("_")}
-            self._db_session.query(User).filter(User.id == user_id).update(user)
+            user_setting = {
+                key: value
+                for key, value in user_setting.__dict__.items()
+                if not key.startswith("_")
+            }
+            self._db_session.query(UserSetting).filter(UserSetting.id == user_id).update(
+                user_setting
+            )
             return None
         except Exception as e:
             logger.error(f"Error updating user: {e}")

--- a/chatbot-core/backend/app/repositories/user.py
+++ b/chatbot-core/backend/app/repositories/user.py
@@ -32,6 +32,7 @@ class UserRepository(BaseRepository):
             Optional[APIError]: API error response
         """
         try:
+            user = {key: value for key, value in user.__dict__.items() if not key.startswith("_")}
             self._db_session.query(User).filter(User.id == user_id).update(user)
             return None
         except Exception as e:

--- a/chatbot-core/backend/app/repositories/user.py
+++ b/chatbot-core/backend/app/repositories/user.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models import User
+from app.repositories.base import BaseRepository
+from app.utils.api.api_response import APIError
+from app.utils.api.error_handler import ErrorCodesMappingNumber
+from app.utils.api.helpers import get_logger
+
+logger = get_logger(__name__)
+
+
+class UserRepository(BaseRepository):
+    def __init__(self, db_session: Session):
+        """
+        User repository class for handling user-related database operations.
+
+        Args:
+            db_session (Session): Database session
+        """
+        super().__init__(db_session=db_session)
+
+    def update_user(self, user_id: str, user: User) -> Optional[APIError]:
+        """
+        Update user.
+
+        Args:
+            user (User): User object
+
+        Returns:
+            Optional[APIError]: API error response
+        """
+        try:
+            self._db_session.query(User).filter(User.id == user_id).update(user)
+            return None
+        except Exception as e:
+            logger.error(f"Error updating user: {e}")
+            return APIError(kind=ErrorCodesMappingNumber.INTERNAL_SERVER_ERROR.value)

--- a/chatbot-core/backend/app/routers/v1/user.py
+++ b/chatbot-core/backend/app/routers/v1/user.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.databases.mssql import get_db_session
+from app.models import User
+from app.models.user import UserSettingRequest
+from app.services.user import UserService
+from app.settings import Constants
+from app.utils.api.api_response import APIResponse
+from app.utils.api.api_response import BackendAPIResponse
+from app.utils.api.error_handler import ErrorCodesMappingNumber
+from app.utils.api.helpers import get_logger
+from app.utils.user.authentication import get_current_user
+
+logger = get_logger(__name__)
+router = APIRouter(prefix="/users", tags=["user", "setting"])
+
+
+@router.patch("/settings", response_model=APIResponse, status_code=status.HTTP_200_OK)
+def update_user_settings(
+    user_setting_request: UserSettingRequest,
+    db_session: Session = Depends(get_db_session),
+    user: User = Depends(get_current_user),
+) -> BackendAPIResponse:
+    """
+    Update user settings.
+
+    Args:
+        user_request (UserRequest): User request object
+        db_session (Session): Database session. Defaults to relational database session.
+        user (User): User object
+
+    Returns:
+        BackendAPIResponse: API response
+    """
+    if not user:
+        status_code, detail = ErrorCodesMappingNumber.UNAUTHORIZED_REQUEST.value
+        raise HTTPException(
+            status_code=status_code,
+            detail=detail,
+        )
+
+    # Update user settings
+    err = UserService(db_session=db_session).update_user_settings(
+        user=user,
+        user_setting_request=user_setting_request,
+    )
+    if err:
+        status_code, detail = err.kind
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    # Parse user settings
+    data = user_setting_request.model_dump(exclude_unset=True)
+
+    return BackendAPIResponse().set_message(message=Constants.API_SUCCESS).set_data(data=data).respond()

--- a/chatbot-core/backend/app/routers/v1/user.py
+++ b/chatbot-core/backend/app/routers/v1/user.py
@@ -16,7 +16,7 @@ from app.utils.api.helpers import get_logger
 from app.utils.user.authentication import get_current_user
 
 logger = get_logger(__name__)
-router = APIRouter(prefix="/users", tags=["user", "setting"])
+router = APIRouter(prefix="/users/me", tags=["user", "setting"])
 
 
 @router.patch("/settings", response_model=APIResponse, status_code=status.HTTP_200_OK)
@@ -55,4 +55,9 @@ def update_user_settings(
     # Parse user settings
     data = user_setting_request.model_dump(exclude_unset=True)
 
-    return BackendAPIResponse().set_message(message=Constants.API_SUCCESS).set_data(data=data).respond()
+    return (
+        BackendAPIResponse()
+        .set_message(message=Constants.API_SUCCESS)
+        .set_data(data=data)
+        .respond()
+    )

--- a/chatbot-core/backend/app/services/base.py
+++ b/chatbot-core/backend/app/services/base.py
@@ -24,9 +24,6 @@ class BaseService:
         Context manager for handling transaction
         """
         try:
-            # Begin the transaction
-            self._db_session.begin()
-
             # Yield the control back to the caller
             yield
 

--- a/chatbot-core/backend/app/services/user.py
+++ b/chatbot-core/backend/app/services/user.py
@@ -1,0 +1,80 @@
+from typing import List
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models import User
+from app.models.user import UserSettingRequest
+from app.repositories.user import UserRepository
+from app.services.base import BaseService
+from app.utils.api.api_response import APIError
+from app.utils.api.helpers import get_logger
+
+logger = get_logger(__name__)
+
+
+class UserService(BaseService):
+    def __init__(self, db_session: Session):
+        """
+        User service class for handling user-related operations.
+
+        Args:
+            db_session (Session): Database session
+        """
+        super().__init__(db_session=db_session)
+
+        self._user_repo = UserRepository(db_session=db_session)
+
+    def _handle_recent_agents(
+        self, recent_agent_ids: Optional[List[str]], current_agent_id: str
+    ) -> Optional[List[str]]:
+        """
+        Handle recent agents.
+
+        Args:
+            recent_agent_ids (Optional[List[str]]): List of recent agent IDs
+            current_agent_id (str): Current agent ID
+
+        Returns:
+            Optional[List[str]]: List of recent agent IDs
+        """
+        if not recent_agent_ids:
+            recent_agent_ids = []
+        else:
+            recent_agent_ids = [agent_id for agent_id in recent_agent_ids if agent_id != current_agent_id]
+
+        # Add the current agent ID to the beginning of the list
+        recent_agent_ids.insert(0, current_agent_id)
+
+        # Limit the number of recent agents to 5
+        recent_agent_ids = recent_agent_ids[:5]
+
+        return recent_agent_ids
+
+    def update_user_settings(self, user: User, user_setting_request: UserSettingRequest) -> Optional[APIError]:
+        """
+        Update user settings.
+
+        Args:
+            user (User): User object
+            user_setting_request (UserSettingRequest): User setting request object
+
+        Returns:
+            Optional[APIError]: API error response
+        """
+        with self._transaction():
+            recent_agent_ids = user.recent_agent_ids
+
+            # Handle update recent agents
+            if user_setting_request.current_agent_id:
+                current_agent_id = user_setting_request.current_agent_id
+                recent_agent_ids = self._handle_recent_agents(
+                    recent_agent_ids=recent_agent_ids, current_agent_id=current_agent_id
+                )
+
+                # Update user recent agents
+                user.recent_agent_ids = recent_agent_ids
+
+            err = self._user_repo.update_user(user_id=user.id, user=user)
+
+        return err if err else None

--- a/chatbot-core/backend/app/services/user.py
+++ b/chatbot-core/backend/app/services/user.py
@@ -63,9 +63,8 @@ class UserService(BaseService):
             Optional[APIError]: API error response
         """
         with self._transaction():
-            recent_agent_ids = user.recent_agent_ids
-
             # Handle update recent agents
+            recent_agent_ids = user.recent_agent_ids
             if user_setting_request.current_agent_id:
                 current_agent_id = user_setting_request.current_agent_id
                 recent_agent_ids = self._handle_recent_agents(
@@ -74,6 +73,9 @@ class UserService(BaseService):
 
                 # Update user recent agents
                 user.recent_agent_ids = recent_agent_ids
+
+            # Update other user settings
+            user.auto_scroll = user_setting_request.auto_scroll
 
             err = self._user_repo.update_user(user_id=user.id, user=user)
 

--- a/chatbot-core/backend/app/services/user.py
+++ b/chatbot-core/backend/app/services/user.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 from typing import Optional
 
@@ -41,17 +42,23 @@ class UserService(BaseService):
         if not recent_agent_ids:
             recent_agent_ids = []
         else:
-            recent_agent_ids = [agent_id for agent_id in recent_agent_ids if agent_id != current_agent_id]
+            recent_agent_ids = [
+                agent_id for agent_id in recent_agent_ids if agent_id != current_agent_id
+            ]
 
         # Add the current agent ID to the beginning of the list
+        logger.info(f"Adding current agent ID: {current_agent_id} to the beginning of the list")
         recent_agent_ids.insert(0, current_agent_id)
 
         # Limit the number of recent agents to 5
         recent_agent_ids = recent_agent_ids[:5]
+        logger.info(f"Current recent agent IDs: {recent_agent_ids}")
 
         return recent_agent_ids
 
-    def update_user_settings(self, user: User, user_setting_request: UserSettingRequest) -> Optional[APIError]:
+    def update_user_settings(
+        self, user: User, user_setting_request: UserSettingRequest
+    ) -> Optional[APIError]:
         """
         Update user settings.
 
@@ -64,15 +71,15 @@ class UserService(BaseService):
         """
         with self._transaction():
             # Handle update recent agents
-            recent_agent_ids = user.recent_agent_ids
+            recent_agent_ids = json.loads(user.recent_agent_ids) if user.recent_agent_ids else []
             if user_setting_request.current_agent_id:
-                current_agent_id = user_setting_request.current_agent_id
+                current_agent_id = str(user_setting_request.current_agent_id)
                 recent_agent_ids = self._handle_recent_agents(
                     recent_agent_ids=recent_agent_ids, current_agent_id=current_agent_id
                 )
 
                 # Update user recent agents
-                user.recent_agent_ids = recent_agent_ids
+                user.recent_agent_ids = json.dumps(recent_agent_ids)
 
             # Update other user settings
             user.auto_scroll = user_setting_request.auto_scroll

--- a/chatbot-core/backend/app/settings/constants.py
+++ b/chatbot-core/backend/app/settings/constants.py
@@ -73,3 +73,6 @@ class Constants:
 
     # Chat Message
     MAX_USER_MESSAGE_LENGTH = 2000
+
+    # User Settings
+    MAX_RECENT_AGENTS = 5

--- a/chatbot-core/backend/app/utils/user/authentication.py
+++ b/chatbot-core/backend/app/utils/user/authentication.py
@@ -1,11 +1,25 @@
 from typing import Optional
 
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.databases.mssql import get_db_session
 from app.models.user import User
+from app.repositories.user import UserRepository
 
 
-async def get_current_user() -> Optional[User]:
+async def get_current_user(db_session: Session = Depends(get_db_session)) -> Optional[User]:
     """
     Get the current user from the request
+
+    Args:
+        db_session (Session): Database session
+
+    Returns:
+        Optional[User]: User object
     """
     # TODO: Implement user authentication
-    return User(id="f6f7b43c-c0ca-4003-8143-7c5e767cde12")
+    user_id = "f6f7b43c-c0ca-4003-8143-7c5e767cde12"
+    user, err = UserRepository(db_session=db_session).get_user(user_id=user_id)
+
+    return user if not err else None


### PR DESCRIPTION
## Description

Add recent agent update feature.

## How Has This Been Tested?

I have defined those endpoints:

### `PATCH /users/settings`

- Check if the API is running.
- How to test ?

```bash
curl -X PATCH 127.0.0.1:5000/api/v1/users/settings -d '{"auto_scroll": false, "current_agent_id": "c262ab96-06a5-46eb-8120-3cf978d11119"}'
```

- Then, we get:

```bash
{
    "message": "Success",
    "headers": null,
    "data": {
        "current_agent_id": "c262ab96-06a5-46eb-8120-3cf978d11119",
        "auto_scroll": false
    }
}
```
