### PR TITLE
feat(backend): Add basic api state management endpoints

### DIFF
--- a/chatbot-core/backend/app/routers/base.py
+++ b/chatbot-core/backend/app/routers/base.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from fastapi import status
 
+from app import __version__
 from app.models.api import APIResponse
 from app.utils.api_response import BackendAPIResponse
 
@@ -8,9 +9,12 @@ router = APIRouter(tags=["base"])
 
 
 @router.get("/", response_model=APIResponse, status_code=status.HTTP_200_OK)
-def home():
+def home() -> BackendAPIResponse:
     """
     Just a simple home endpoint to show the API's information
+
+    Returns:
+        BackendAPIResponse: API response
     """
     return (
         BackendAPIResponse()
@@ -24,9 +28,23 @@ def home():
     )
 
 
-@router.get("/ping", response_model=APIResponse, status_code=status.HTTP_200_OK)
-def ping():
+@router.get("/health", response_model=APIResponse, status_code=status.HTTP_200_OK)
+def healthcheck() -> BackendAPIResponse:
     """
     Just a simple ping endpoint to check if the API is running
+
+    Returns:
+        BackendAPIResponse: API response
     """
-    return BackendAPIResponse().set_message("Pong!").respond()
+    return BackendAPIResponse().set_message("ok!").respond()
+
+
+@router.get("/version", response_model=APIResponse, status_code=status.HTTP_200_OK)
+def version() -> BackendAPIResponse:
+    """
+    Just a simple endpoint to show the API's version
+
+    Returns:
+        BackendAPIResponse: API response
+    """
+    return BackendAPIResponse().set_data({"version": __version__}).respond()


### PR DESCRIPTION
## Description

Add basic api state management endpoints

## How Has This Been Tested?

I have defined those endpoints:

### `GET /health`

- Check if the API is running.
- How to test ?

```bash
curl -X GET 127.0.0.1:5000/health
```

- Then, we get:

```bash
{
    "message": "ok!",
    "headers": null,
    "data": null
}
```

### `GET /version`

- Get the API's version.
- How to test ?

```bash
curl -X GET 127.0.0.1:5000/version
```

- Then, we get:

```bash
{
    "message": "Success",
    "headers": null,
    "data": {
        "version": "1.0.0"
    }
}
```