### PR TITLE
docs: fix qdrant's document path

### DIFF
--- a/docs/blog/hardwareResourcing.mdx
+++ b/docs/blog/hardwareResourcing.mdx
@@ -73,7 +73,7 @@ These following ports are used by services:
 
 - `1433`: For communcating with SQL Server as `database`
 - `6379`: For communicating with Redis as `cache`
-- `6333`: For communicating with Qdrant as `index` via HTTP API, for the [Monitoring](/documentation/guides/monitoring/) health and metrics endpoints
+- `6333`: For communicating with Qdrant as `index` via HTTP API, for the [Monitoring](https://qdrant.tech/documentation/guides/monitoring/) health and metrics endpoints
 - `6334`: For communicating with Qdrant via gRPC
 - `9000`: For access web interface of MinIO as `object_storage`
 - `9001`: For communicating with MinIO API as `object_storage`


### PR DESCRIPTION
## Description

Fix wrong document path to Qdrant's docs.

## How Has This Been Tested?

![image](https://github.com/user-attachments/assets/25a3f03a-98c5-4ac0-91ed-d4c8e300693d)

## Related Issue(s)

#86 
