### PR TITLE
fix(backend): Remove duplicated field

### DIFF
--- a/chatbot-core/backend/app/models/document.py
+++ b/chatbot-core/backend/app/models/document.py
@@ -23,7 +23,6 @@ class DocumentMetadata(Base):
     id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
         UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, index=True, default=uuid4
     )
-    hidden: Mapped[bool] = mapped_column(Boolean, default=False)
     name: Mapped[str] = mapped_column(String)
     link: Mapped[str] = mapped_column(String)
     last_synced_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))


### PR DESCRIPTION
## Description

The table `document_metadata` has two fields `hidden` and `is_public` which aim to the publicity of the document. These are duplicated fields, so I decided to keep only the field `is_public`.