### PR TITLE
fix(backend): remove foreign key user__chat_message

### DIFF
--- a/chatbot-core/backend/app/models/chat.py
+++ b/chatbot-core/backend/app/models/chat.py
@@ -145,9 +145,6 @@ class ChatMessage(Base):
     id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
         UNIQUEIDENTIFIER(as_uuid=True), primary_key=True, default=uuid4
     )
-    user_id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
-        ForeignKey("user.id", ondelete="CASCADE"), nullable=False
-    )
     chat_session_id: Mapped[UNIQUEIDENTIFIER] = mapped_column(
         ForeignKey("chat_session.id", ondelete="CASCADE"), nullable=False
     )
@@ -186,7 +183,6 @@ class ChatMessage(Base):
     )
 
     # Define relationships. We use the type hinting string to avoid circular imports.
-    user: Mapped["User"] = relationship("User", back_populates="chat_messages")
     chat_session: Mapped["ChatSession"] = relationship(
         "ChatSession", back_populates="chat_messages"
     )

--- a/chatbot-core/backend/app/models/prompt.py
+++ b/chatbot-core/backend/app/models/prompt.py
@@ -34,7 +34,7 @@ class Prompt(Base):
     )
     agent_id: Mapped[UNIQUEIDENTIFIER] = mapped_column(ForeignKey("agent.id"), nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
-    description: Optional[Mapped[str]] = mapped_column(String, nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     system_prompt: Mapped[str] = mapped_column(Text, nullable=False)
     task_prompt: Mapped[str] = mapped_column(Text, nullable=False)
     include_citations: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -13,7 +13,6 @@ from app.models.base import Base
 
 if TYPE_CHECKING:
     from app.models import ChatSession
-    from app.models import ChatMessage
     from app.models import Folder
 
 
@@ -31,5 +30,4 @@ class User(Base):
     )
 
     chat_sessions: Mapped[List["ChatSession"]] = relationship("ChatSession", back_populates="user")
-    chat_messages: Mapped[List["ChatMessage"]] = relationship("ChatMessage", back_populates="user")
     folders: Mapped[List["Folder"]] = relationship("Folder", back_populates="user")

--- a/chatbot-core/backend/app/services/chat.py
+++ b/chatbot-core/backend/app/services/chat.py
@@ -232,7 +232,6 @@ class ChatService(BaseService):
 
         # Create chat request message
         new_chat_request = ChatMessage(
-            user_id=user_id,
             chat_session_id=chat_session_id,
             parent_message_id=parent_message_id,
             message=message,
@@ -266,7 +265,6 @@ class ChatService(BaseService):
         self,
         chat_message_request: ChatMessageRequest,
         chat_session_id: str,
-        user_id: str,
         current_request_id: str,
     ) -> Tuple[Optional[ChatMessage], Optional[APIError]]:
         """
@@ -276,7 +274,6 @@ class ChatService(BaseService):
         Args:
             chat_message_request(ChatMessageRequest): Chat message request object
             chat_session_id(str): Chat session id
-            user_id(str): User id
             current_request_id(str): Current request message id
             latest_response_id(str): Latest response message id. Defaults to None
 
@@ -287,7 +284,6 @@ class ChatService(BaseService):
         # TODO: Implement the logic to query the LLM model and generate the response
         response_message = chat_message_request.message + " (Response)"
         current_chat_response = ChatMessage(
-            user_id=user_id,
             chat_session_id=chat_session_id,
             parent_message_id=current_request_id,
             message=response_message,
@@ -506,7 +502,6 @@ class ChatService(BaseService):
 
         # Generate chat response
         chat_response, err = self._generate_chat_response(
-            user_id=user_id,
             chat_message_request=chat_message_request,
             chat_session_id=chat_session_id,
             current_request_id=new_chat_request.id,


### PR DESCRIPTION
## Problem

![27c6acf9bacd07935edc](https://github.com/user-attachments/assets/fefb95ca-7ec8-40df-8e0c-017893560489)

Alembic is facing conflict in foreign keys with tables `user`, `chat_session` and `chat_message`, that causes conflict in table creation when I run `alembic upgrade head`.

### Solution

Remove FK key between `user` and `chat_message`. From now on, the relationships are describe below:
- 1 user has many chat sessions
- 1 chat session has many chat messages

**Use case:**
- When a user wants to get all chat messages, backend first query all chat sessions => join chat messages to take all chat messages
- When a user wants to edit a chat message, first retrieve that chat message's `chat_session_id` => then do the update

## How Has This Been Tested?

Success when run `alembic upgrade head`:

![image](https://github.com/user-attachments/assets/2761a234-c10a-427b-8a06-968c97483436)

## Accepted Risk

- Slower query all chat messages from a user
- N+1 problem (I'm not sure)

## Related Issue(s)

- Root issue: #51 
- Affected issue: #57 

## Checklist:

- [x] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [x] Author has done a final read through of the PR right before merge
