### PR TITLE
feat(backend): Add get current user information and user settings endpoint

### DIFF
--- a/chatbot-core/backend/app/models/chat.py
+++ b/chatbot-core/backend/app/models/chat.py
@@ -255,7 +255,6 @@ class ChatMessageResponse(BaseModel):
     """
 
     id: UUID = Field(..., description="Chat message id")
-    user_id: UUID = Field(..., description="User id")
     chat_session_id: UUID = Field(..., description="Chat session id")
     message: str = Field(..., description="Message text")
     message_type: ChatMessageType = Field(..., description="Message type")

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -59,6 +59,21 @@ class User(Base):
     user_setting: Mapped["UserSetting"] = relationship("UserSetting", back_populates="user")
 
 
+class UserResponse(BaseModel):
+    """
+    Pydantic model for user response.
+    Defines the fields that can be returned in the user.
+    """
+
+    id: UUID = Field(..., description="User ID")
+    created_at: datetime = Field(..., description="Created at")
+    updated_at: datetime = Field(..., description="Updated at")
+    deleted_at: Optional[datetime] = Field(None, description="Deleted at")
+
+    class Config:
+        from_attributes = True
+
+
 class UserSetting(Base):
     """
     Represents the user settings in the chatbot system.

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -100,6 +100,22 @@ class UserSettingRequest(BaseModel):
     current_agent_id: Optional[UUID] = Field(None, title="Current using agent ID")
     auto_scroll: bool = Field(True, title="Auto scroll chat messages")
     default_model: Optional[str] = Field(None, title="Default model for the user")
+    maximum_chat_retention_days: Optional[int] = Field(None, title="Maximum chat retention days")
+
+    class Config:
+        from_attributes = True
+
+
+class UserSettingResponse(BaseModel):
+    """
+    Pydantic model for user settings response.
+    Defines the fields that can be returned in the user settings.
+    """
+
+    recent_agent_ids: Optional[List[UUID]] = Field(None, title="List of recent agent IDs")
+    auto_scroll: bool = Field(..., title="Auto scroll chat messages")
+    default_model: Optional[str] = Field(None, title="Default model for the user")
+    maximum_chat_retention_days: Optional[int] = Field(None, title="Maximum chat retention days")
 
     class Config:
         from_attributes = True

--- a/chatbot-core/backend/app/models/user.py
+++ b/chatbot-core/backend/app/models/user.py
@@ -97,10 +97,12 @@ class UserSettingRequest(BaseModel):
     Defines the fields that can be updated in the user settings.
     """
 
-    current_agent_id: Optional[UUID] = Field(None, title="Current using agent ID")
-    auto_scroll: bool = Field(True, title="Auto scroll chat messages")
-    default_model: Optional[str] = Field(None, title="Default model for the user")
-    maximum_chat_retention_days: Optional[int] = Field(None, title="Maximum chat retention days")
+    current_agent_id: Optional[UUID] = Field(None, description="Current using agent ID")
+    auto_scroll: bool = Field(True, description="Auto scroll chat messages")
+    default_model: Optional[str] = Field(None, description="Default model for the user")
+    maximum_chat_retention_days: Optional[int] = Field(
+        None, description="Maximum chat retention days"
+    )
 
     class Config:
         from_attributes = True
@@ -112,10 +114,12 @@ class UserSettingResponse(BaseModel):
     Defines the fields that can be returned in the user settings.
     """
 
-    recent_agent_ids: Optional[List[UUID]] = Field(None, title="List of recent agent IDs")
-    auto_scroll: bool = Field(..., title="Auto scroll chat messages")
-    default_model: Optional[str] = Field(None, title="Default model for the user")
-    maximum_chat_retention_days: Optional[int] = Field(None, title="Maximum chat retention days")
+    recent_agent_ids: Optional[List[UUID]] = Field(None, description="List of recent agent IDs")
+    auto_scroll: bool = Field(..., description="Auto scroll chat messages")
+    default_model: Optional[str] = Field(None, description="Default model for the user")
+    maximum_chat_retention_days: Optional[int] = Field(
+        None, description="Maximum chat retention days"
+    )
 
     class Config:
         from_attributes = True

--- a/chatbot-core/backend/app/routers/v1/user.py
+++ b/chatbot-core/backend/app/routers/v1/user.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import Session
 from app.databases.mssql import get_db_session
 from app.models import User
 from app.models.user import UserSettingRequest
-from app.services.user import UserService
+from app.models.user import UserSettingResponse
+from app.services.user import UserSettingService
 from app.settings import Constants
 from app.utils.api.api_response import APIResponse
 from app.utils.api.api_response import BackendAPIResponse
@@ -17,6 +18,50 @@ from app.utils.user.authentication import get_current_user
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/users/me", tags=["user", "setting"])
+
+
+@router.get("/settings", response_model=APIResponse, status_code=status.HTTP_200_OK)
+def get_user_settings(
+    db_session: Session = Depends(get_db_session),
+    user: User = Depends(get_current_user),
+) -> BackendAPIResponse:
+    """
+    Get user settings.
+
+    Args:
+        db_session (Session): Database session. Defaults to relational database session.
+        user (User): User object
+
+    Returns:
+        BackendAPIResponse: API response
+    """
+    if not user:
+        status_code, detail = ErrorCodesMappingNumber.UNAUTHORIZED_REQUEST.value
+        raise HTTPException(
+            status_code=status_code,
+            detail=detail,
+        )
+
+    # Get user settings
+    user_settings, err = UserSettingService(db_session=db_session).get_user_settings(
+        user_id=user.id
+    )
+    if err:
+        status_code, detail = err.kind
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    # Parse user settings
+    if user_settings:
+        data = UserSettingResponse.model_validate(user_settings)
+    else:
+        data = None
+
+    return (
+        BackendAPIResponse()
+        .set_message(message=Constants.API_SUCCESS)
+        .set_data(data=data)
+        .respond()
+    )
 
 
 @router.patch("/settings", response_model=APIResponse, status_code=status.HTTP_200_OK)
@@ -44,8 +89,8 @@ def update_user_settings(
         )
 
     # Update user settings
-    err = UserService(db_session=db_session).update_user_settings(
-        user=user,
+    err = UserSettingService(db_session=db_session).update_user_settings(
+        user_id=user.id,
         user_setting_request=user_setting_request,
     )
     if err:

--- a/chatbot-core/backend/app/routers/v1/user.py
+++ b/chatbot-core/backend/app/routers/v1/user.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.databases.mssql import get_db_session
 from app.models import User
+from app.models.user import UserResponse
 from app.models.user import UserSettingRequest
 from app.models.user import UserSettingResponse
 from app.services.user import UserSettingService
@@ -18,6 +19,38 @@ from app.utils.user.authentication import get_current_user
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/users/me", tags=["user", "setting"])
+
+
+@router.get("", response_model=APIResponse, status_code=status.HTTP_200_OK)
+def get_user(
+    user: User = Depends(get_current_user),
+) -> BackendAPIResponse:
+    """
+    Get user.
+
+    Args:
+        db_session (Session): Database session. Defaults to relational database session.
+        user (User): User object
+
+    Returns:
+        BackendAPIResponse: API response
+    """
+    if not user:
+        status_code, detail = ErrorCodesMappingNumber.UNAUTHORIZED_REQUEST.value
+        raise HTTPException(
+            status_code=status_code,
+            detail=detail,
+        )
+
+    # Parse user
+    data = UserResponse.model_validate(user)
+
+    return (
+        BackendAPIResponse()
+        .set_message(message=Constants.API_SUCCESS)
+        .set_data(data=data)
+        .respond()
+    )
 
 
 @router.get("/settings", response_model=APIResponse, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
## Description

Add get current user information and user settings endpoint

### `GET /users/me`

- List current user information.
- How to test ?

```bash
curl -X GET 127.0.0.1:5000/api/v1/users/me
```

- Then, we get:

```bash
{
    "message": "Success",
    "headers": null,
    "data": {
        "id": "f6f7b43c-c0ca-4003-8143-7c5e767cde12",
        "created_at": "2024-12-19T16:37:58.583333Z",
        "updated_at": "2024-12-19T16:37:58.583333Z",
        "deleted_at": null
    }
}
```

### `GET /users/me/settings`

- List current user's settings.
- How to test ?

```bash
curl -X GET 127.0.0.1:5000/api/v1/users/me/settings
```

- Then, we get:

```bash
{
    "message": "Success",
    "headers": null,
    "data": {
        "recent_agent_ids": [
            "c262ab96-06a5-46eb-8120-3cf978d11180",
            "c262ab96-06a5-46eb-8120-3cf978d11176",
            "c262ab96-06a5-46eb-8120-3cf978d11172"
        ],
        "auto_scroll": false,
        "default_model": "o1-pro",
        "maximum_chat_retention_days": null
    }
}
```

