### PR TITLE
style(env): add envrc for those want to use direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 **/env.bak/
 **/venv.bak/
 **/.python-version
+**/.env.*
+chatbot-core/.envrc
 
 # Docs
 docs/.next

--- a/chatbot-core/.env.example
+++ b/chatbot-core/.env.example
@@ -1,4 +1,4 @@
-ENV=dev # dev, test, prod
+ENV=development # development, production
 PROJECT=chatbot-core
 API_VERSION=1.0.0
 
@@ -9,13 +9,14 @@ EMBEDDING_MODEL=text-embedding-3-small
 # SQL SERVER Database
 MSSQL_HOST=database
 MSSQL_USER=SA
-MSSQL_SA_PASSWORD=P&ssword123
+MSSQL_SA_PASSWORD="P&ssword123"
 MSSQL_DB=chatbot_core
+DATABASE_URL=
 
 # Minio Object Storage
 MINIO_ENDPOINT=object-storage:9000
 MINIO_ROOT_USER=S3User
-MINIO_ROOT_PASSWORD=P&ssword123
+MINIO_ROOT_PASSWORD="P&ssword123"
 
 # Qdrant
 QDRANT_HOST=index

--- a/deployment/docker_compose/.env.example
+++ b/deployment/docker_compose/.env.example
@@ -1,8 +1,8 @@
-ENV=dev # dev, test, prod
+ENV=development # development, production
 
 # SQL Server Database
 MSSQL_USER=SA
-MSSQL_SA_PASSWORD=P&ssword123
+MSSQL_SA_PASSWORD="P&ssword123"
 
 # Minio Object Storage
 MINIO_ROOT_USER=S3User

--- a/deployment/docker_compose/docker-compose.dev.yaml
+++ b/deployment/docker_compose/docker-compose.dev.yaml
@@ -147,7 +147,7 @@ services:
       - "5000:5000"
     env_file:
       - ./.env
-      - ../../chatbot-core/.env
+      - ../../chatbot-core/.env.${ENV}
     volumes: # INFO: Mount for auto-reload code changes
       - ../../chatbot-core/backend/alembic/:/app/alembic
       - ../../chatbot-core/backend/app/:/app/app


### PR DESCRIPTION
## Description

- Add envrc for those want to use direnv
- Edit some environment variables

## How Has This Been Tested?

1. Install [direnv](https://direnv.net/docs/installation.html)
2. Copy sample envrc
```bash
cd chatbot-core
cp .envrc.sample .envrc
```
3. Allow direnv
```bash
direnv allow
```

## Accepted Risk

No risks.

## Related Issue(s)

Issue #14 

## Checklist:

- [x] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
