### PR TITLE
build(frontend): configure docker for frontend v2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 python 3.11.10
-yarn 1.20.0
+yarn 1.22.22
 uv 0.5.4
+nodejs 22.12.0

--- a/chatbot-core/frontend-v2/.dockerignore
+++ b/chatbot-core/frontend-v2/.dockerignore
@@ -1,0 +1,6 @@
+.vscode/
+.gitignore
+node_modules/
+.next
+Dockerfile
+.dockerignore

--- a/chatbot-core/frontend-v2/Dockerfile
+++ b/chatbot-core/frontend-v2/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: Build the app
+FROM node:22.12.0-alpine AS build
+
+WORKDIR /app
+
+# Copy package.json and yarn.lock to /app
+COPY package.json yarn.lock ./
+
+# Install dependencies
+RUN yarn install --frozen-lockfile && \
+  yarn cache clean
+
+# Copy the rest of the files to /app
+COPY . .
+
+# Build the app
+RUN yarn build
+
+# Stage 2: Serve the app with nginx
+FROM nginx:1.23.4-alpine AS serve
+
+# Copy the build output to replace the default nginx contents
+COPY --from=build /app/out /var/www/out
+
+EXPOSE 80
+
+# Tail to /dev/null to keep the container running
+CMD ["tail", "-f", "/dev/null"]

--- a/deployment/data/nginx/app.conf
+++ b/deployment/data/nginx/app.conf
@@ -4,7 +4,7 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       'rt=$request_time';
 
-upstream api-server {
+upstream backend {
     # fail_timeout=0 means we always retry an upstream even if it failed
     # to return a good HTTP response
 
@@ -16,10 +16,6 @@ upstream api-server {
     server api-server:5000 fail_timeout=0;
 }
 
-upstream web-server {
-    server web-server:3000 fail_timeout=0;
-}
-
 server {
     listen 80;
     server_name localhost;
@@ -27,6 +23,8 @@ server {
     client_max_body_size 5G;    # Maximum upload size    
 
     access_log /var/log/nginx/access.log custom_main;
+
+    root /var/www/out;
 
     # Match both /api/* and /openapi.json in a single rule
     location ~ ^/(api|openapi.json)(/.*)?$ {
@@ -47,7 +45,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api-server;
+        proxy_pass http://backend;
     }
 
     location / {
@@ -63,7 +61,13 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web-server;
+        try_files $uri $uri.html $uri/ =404;
+    }
+
+    # error handling for 404 pages
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
     }
 }
 

--- a/deployment/data/nginx/app.conf.template.dev
+++ b/deployment/data/nginx/app.conf.template.dev
@@ -4,7 +4,7 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       'rt=$request_time';
 
-upstream api-server {
+upstream backend {
     # fail_timeout=0 means we always retry an upstream even if it failed
     # to return a good HTTP response
 
@@ -16,10 +16,6 @@ upstream api-server {
     server api-server:5000 fail_timeout=0;
 }
 
-upstream web-server {
-    server web-server:3000 fail_timeout=0;
-}
-
 server {
     listen 80;
     server_name ${DOMAIN};
@@ -27,6 +23,8 @@ server {
     client_max_body_size 5G;    # Maximum upload size    
 
     access_log /var/log/nginx/access.log custom_main;
+
+    root /var/www/out;
 
     # Match both /api/* and /openapi.json in a single rule
     location ~ ^/(api|openapi.json)(/.*)?$ {
@@ -47,7 +45,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api-server;
+        proxy_pass http://backend;
     }
 
     location / {
@@ -63,7 +61,13 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web-server;
+        try_files $uri $uri.html $uri/ =404;
+    }
+
+    # error handling for 404 pages
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
     }
 }
 

--- a/deployment/docker_compose/docker-compose.dev.yaml
+++ b/deployment/docker_compose/docker-compose.dev.yaml
@@ -31,6 +31,9 @@ services:
       retries: 3
       start_period: 3s
 
+  # INFO: This service is used to configure the database
+  # After the database is up and running, this service will auto exit
+  # Ignore it
   database.configurator:
     image: mcr.microsoft.com/mssql/server:2019-CU29-GDR1-ubuntu-20.04
     platform: linux/amd64
@@ -147,7 +150,7 @@ services:
       - "5000:5000"
     env_file:
       - ./.env
-      - ../../chatbot-core/.env.${ENV} # INFO: ENV here can be development or production
+      - ../../chatbot-core/.env.${ENV} # INFO: can be .env.development or .env.production
     volumes: # INFO: Mount for auto-reload code changes
       - ../../chatbot-core/backend/alembic/:/app/alembic
       - ../../chatbot-core/backend/app/:/app/app
@@ -162,54 +165,36 @@ services:
         max-size: "50m"
         max-file: "6"
 
-  # web-server:
-  #   build:
-  #     context: ../../chatbot-core/frontend
-  #     dockerfile: dev.Dockerfile
-  #   container_name: web-server
-  #   hostname: web-server
-  #   restart: on-failure
-  #   depends_on:
-  #     - api-server
-  #   ports:
-  #     - "3000:3000"  # Ensure the dev server is exposed on port 3000
-  #   networks:
-  #     - backend
-  #     - frontend
-  #   env_file:
-  #     - ./.env
-  #   volumes:
-  #     - ../../chatbot-core/frontend:/app  # Mount the source code into the container
-  #     - /app/node_modules  # Avoid node_modules conflicts
-  #   command: >
-  #     /bin/sh -c "npm install && npm run dev"
-
-
-  # nginx:
-  #   image: nginx:1.23.4-alpine
-  #   restart: on-failure
-  #   depends_on:
-  #     - api-server
-  #     - web-server
-  #   environment:
-  #     - DOMAIN=localhost
-  #   ports:
-  #     - "8000:80"
-  #     - "3003:80"
-  #   volumes:
-  #     - ../data/nginx:/etc/nginx/conf.d
-  #   networks:
-  #     - frontend
-  #     - backend
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   command: >
-  #     /bin/sh -c "chmod +x /etc/nginx/conf.d/run-nginx.sh 
-  #     && dos2unix /etc/nginx/conf.d/run-nginx.sh
-  #     && /etc/nginx/conf.d/run-nginx.sh app.conf.template.dev"
+  web-server:
+    build:
+      context: ../../chatbot-core/frontend-v2
+      dockerfile: Dockerfile
+    container_name: web-server
+    hostname: web-server
+    restart: on-failure
+    depends_on:
+      - api-server
+    environment:
+      - DOMAIN=localhost
+    ports:
+      - "3000:80"
+    volumes:
+      - ../data/nginx:/etc/nginx/conf.d
+      - /app/node_modules # Avoid node_modules conflicts
+    networks:
+      - frontend
+      - backend
+    env_file:
+      - ./.env
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+    command: >
+      /bin/sh -c "chmod +x /etc/nginx/conf.d/run-nginx.sh
+      && dos2unix /etc/nginx/conf.d/run-nginx.sh
+      && /etc/nginx/conf.d/run-nginx.sh app.conf.template.dev"
 
 volumes:
   mssql_data_volume:


### PR DESCRIPTION
## Description

Configure docker compose service for frontend:

1. Build frontend to static files
2. Serve under nginx

The service name: `web-server`
Ports: 3000

## How Has This Been Tested?

1. Go to `chatbot-core`
2. Run `make build` to build backend and frontend images
4. Run `make up` to spawn up services
5. Access http://localhost:3000
6. Every necessary commands is at `make help`

## Accepted Risk

Not configured `.env` file for frontend.

## Related Issue(s)

#134 

## Checklist:

- [x] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [x] Author has done a final read through of the PR right before merge
