### PR TITLE
ci(auto-prune): add ci workflow to auto prune staled branches

### DIFF
--- a/.github/workflows/prune-staled-branches.yml
+++ b/.github/workflows/prune-staled-branches.yml
@@ -1,0 +1,32 @@
+name: Prune Stale Remote Branches
+# Used to prune all stale remote branches
+# This action will remove all remote branches that have been deleted on the remote repository
+# Schedule to run monthly on the 1st at midnight UTC
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+  workflow_dispatch:
+
+jobs:
+  prune-branches:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      # Step 2: Set up Git
+      - name: Configure Git
+        run: |
+          # Use the ubunchuu bot to appreciate the ubunchuu team
+          git config user.name "ubunchuu[bot]"
+          git config --global user.email '159746302+ubunchuu-admin@users.noreply.github.com'
+
+      # Step 3: Fetch and prune remote branches
+      - name: Prune Remote Branches
+        run: |
+          git fetch --prune
+          echo "Pruned stale branches from remote."


### PR DESCRIPTION
## Description

Added a CI workflow to automatically prune all staled (not used anymore) branches. Scheduled every month.

<!-- Provide a brief description of the changes in this PR -->

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

## Accepted Risk

<!-- Any know risks or failure modes to point out to reviewers -->

## Related Issue(s)

<!-- If applicable, link to the issue(s) this PR addresses -->

## Checklist:

- [x] Author has done a final read through of the PR right before merge
- [x] All tests passed
- [ ] Code review
- [x] (Optional) If there are migrations, they have been rebased to latest main
- [x] (Optional) If there are new dependencies, they are added to the requirements
- [x] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [x] (Optional) Docker images build and basic functionalities work
