### PR TITLE
feat(frontend): implement chat sessions drag and drop feature

### DIFF
--- a/chatbot-core/frontend/package.json
+++ b/chatbot-core/frontend/package.json
@@ -39,8 +39,6 @@
     "next": "14.2.22",
     "next-themes": "^0.4.4",
     "react": "^18",
-    "react-dnd": "^16.0.1",
-    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18",
     "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.54.2",

--- a/chatbot-core/frontend/package.json
+++ b/chatbot-core/frontend/package.json
@@ -15,6 +15,7 @@
     "build"
   ],
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.2",

--- a/chatbot-core/frontend/package.json
+++ b/chatbot-core/frontend/package.json
@@ -36,6 +36,8 @@
     "next": "14.2.22",
     "next-themes": "^0.4.4",
     "react": "^18",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18",
     "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.54.2",

--- a/chatbot-core/frontend/package.json
+++ b/chatbot-core/frontend/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.2",
@@ -32,6 +33,7 @@
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dnd-kit": "^0.0.2",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
     "next": "14.2.22",

--- a/chatbot-core/frontend/src/components/chat-session-item/chat-session-button.tsx
+++ b/chatbot-core/frontend/src/components/chat-session-item/chat-session-button.tsx
@@ -30,7 +30,6 @@ export const ChatSessionButton: FC<IChatSessionButtonProps> = ({
   const style = transform
     ? {
         transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
-        zIndex: 9999, // Make the button float on top
       }
     : undefined;
   return (

--- a/chatbot-core/frontend/src/components/chat-session-item/chat-session-button.tsx
+++ b/chatbot-core/frontend/src/components/chat-session-item/chat-session-button.tsx
@@ -1,3 +1,4 @@
+import { useDraggable } from '@dnd-kit/core';
 import { FC, ReactNode } from 'react';
 
 import { cn } from '@/lib/utils';
@@ -5,14 +6,17 @@ import { cn } from '@/lib/utils';
 import { SidebarMenuButton, SidebarMenuSubButton } from '../ui/sidebar';
 
 interface IChatSessionButtonProps {
+  id: string;
   subItem?: boolean;
   isOpenDropdown: boolean;
   isDropdownHovered: boolean;
   children: ReactNode;
+
   onClick?(): void;
 }
 
 export const ChatSessionButton: FC<IChatSessionButtonProps> = ({
+  id,
   subItem,
   isOpenDropdown,
   isDropdownHovered,
@@ -20,10 +24,21 @@ export const ChatSessionButton: FC<IChatSessionButtonProps> = ({
   onClick,
 }) => {
   const SidebarButton = subItem ? SidebarMenuSubButton : SidebarMenuButton;
-
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: id,
+  });
+  const style = transform
+    ? {
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+      }
+    : undefined;
   return (
     <SidebarButton asChild onClick={onClick}>
       <div
+        ref={setNodeRef}
+        style={style}
+        {...listeners}
+        {...attributes}
         className={cn(
           'relative whitespace-nowrap group/chat-item',
           (isOpenDropdown || isDropdownHovered) && 'bg-sidebar-accent',

--- a/chatbot-core/frontend/src/components/chat-session-item/chat-session-button.tsx
+++ b/chatbot-core/frontend/src/components/chat-session-item/chat-session-button.tsx
@@ -30,6 +30,7 @@ export const ChatSessionButton: FC<IChatSessionButtonProps> = ({
   const style = transform
     ? {
         transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+        zIndex: 9999, // Make the button float on top
       }
     : undefined;
   return (

--- a/chatbot-core/frontend/src/components/chat-session-item/chat-session-item.tsx
+++ b/chatbot-core/frontend/src/components/chat-session-item/chat-session-item.tsx
@@ -29,6 +29,7 @@ const ChatSessionItemComponent: FC<IChatSessionItemProps> = ({ chatSession, subI
   return (
     <SidebarItem className={cn('group/chat-action cursor-pointer relative')}>
       <ChatSessionButton
+        id={chatSession.id}
         subItem={subItem}
         isDropdownHovered={isDropdownHovered}
         isOpenDropdown={isOpenDropdown}

--- a/chatbot-core/frontend/src/constants/sidebar-items.ts
+++ b/chatbot-core/frontend/src/constants/sidebar-items.ts
@@ -1,0 +1,1 @@
+export const SIDEBAR_CHAT_HISTORY = 'chat-history';

--- a/chatbot-core/frontend/src/providers/chat-drag-n-drop-provider.tsx
+++ b/chatbot-core/frontend/src/providers/chat-drag-n-drop-provider.tsx
@@ -34,7 +34,7 @@ type Props = {
   children: ReactNode;
 };
 
-const DndContextProvider: FC<Props> = ({ children }) => {
+const ChatSidebarDndProvider: FC<Props> = ({ children }) => {
   const handleDragEnd = useHandleDragEnd();
 
   return (
@@ -44,4 +44,4 @@ const DndContextProvider: FC<Props> = ({ children }) => {
   );
 };
 
-export default DndContextProvider;
+export default ChatSidebarDndProvider;

--- a/chatbot-core/frontend/src/providers/chat-drag-n-drop-provider.tsx
+++ b/chatbot-core/frontend/src/providers/chat-drag-n-drop-provider.tsx
@@ -4,6 +4,7 @@ import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import React, { FC, ReactNode } from 'react';
 import { toast } from 'sonner';
 
+import { SIDEBAR_CHAT_HISTORY } from '@/constants/sidebar-items';
 import { useEditChatSession } from '@/hooks/chat/use-edit-chat-session';
 
 const useHandleDragEnd = () => {
@@ -14,7 +15,7 @@ const useHandleDragEnd = () => {
       mutate(
         {
           chatSessionId: `${event.active.id}`,
-          data: { folder_id: `${event.over.id}` === 'chat-history' ? null : `${event.over.id}` },
+          data: { folder_id: `${event.over.id}` === SIDEBAR_CHAT_HISTORY ? null : `${event.over.id}` },
         },
         {
           onSuccess() {

--- a/chatbot-core/frontend/src/providers/chat-drag-n-drop-provider.tsx
+++ b/chatbot-core/frontend/src/providers/chat-drag-n-drop-provider.tsx
@@ -1,20 +1,21 @@
 'use client';
 import { DndContext, DragEndEvent } from '@dnd-kit/core';
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { toast } from 'sonner';
 
 import { useEditChatSession } from '@/hooks/chat/use-edit-chat-session';
 
 const useHandleDragEnd = () => {
-  const [, setIsDropped] = useState(false);
   const { mutate } = useEditChatSession();
 
   return (event: DragEndEvent) => {
     if (event.over) {
-      setIsDropped(true);
       mutate(
-        { chatSessionId: `${event.active.id}`, data: { folder_id: `${event.over.id}` } },
+        {
+          chatSessionId: `${event.active.id}`,
+          data: { folder_id: `${event.over.id}` === 'chat-history' ? null : `${event.over.id}` },
+        },
         {
           onSuccess() {
             toast.success('Move chat successfully!');

--- a/chatbot-core/frontend/src/providers/drag-n-drop-provider.tsx
+++ b/chatbot-core/frontend/src/providers/drag-n-drop-provider.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import React, { FC, ReactNode, useState } from 'react';
+import { toast } from 'sonner';
+
+import { useEditChatSession } from '@/hooks/chat/use-edit-chat-session';
+
+const useHandleDragEnd = () => {
+  const [, setIsDropped] = useState(false);
+  const { mutate } = useEditChatSession();
+
+  return (event: DragEndEvent) => {
+    if (event.over) {
+      setIsDropped(true);
+      mutate(
+        { chatSessionId: `${event.active.id}`, data: { folder_id: `${event.over.id}` } },
+        {
+          onSuccess() {
+            toast.success('Move chat successfully!');
+          },
+          onError() {
+            toast.error('Move chat failed.', {
+              description: "There's something wrong with your request. Please try again later!",
+            });
+          },
+        },
+      );
+    }
+  };
+};
+
+type Props = {
+  children: ReactNode;
+};
+
+const DndContextProvider: FC<Props> = ({ children }) => {
+  const handleDragEnd = useHandleDragEnd();
+
+  return (
+    <DndContext modifiers={[restrictToVerticalAxis]} onDragEnd={handleDragEnd}>
+      {children}
+    </DndContext>
+  );
+};
+
+export default DndContextProvider;

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 
 import { Sidebar, SidebarContent, SidebarFooter, SidebarSeparator } from '@/components/ui/sidebar';
-import DndContextProvider from '@/providers/drag-n-drop-provider';
+import ChatSidebarDndProvider from '@/providers/chat-drag-n-drop-provider';
 
 import { AppSidebarHeader } from './app-sidebar-header';
 import { ChatFolders } from './chat-folders/chat-folders';
@@ -13,13 +13,13 @@ export function AppSidebar() {
     <Sidebar>
       <AppSidebarHeader />
       <SidebarSeparator className="mt-1" />
-      <DndContextProvider>
+      <ChatSidebarDndProvider>
         <SidebarContent>
           <ChatFolders />
           <SidebarSeparator />
           <ChatHistory />
         </SidebarContent>
-      </DndContextProvider>
+      </ChatSidebarDndProvider>
       <SidebarFooter />
     </Sidebar>
   );

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { DndContext } from '@dnd-kit/core';
 
 import { Sidebar, SidebarContent, SidebarFooter, SidebarSeparator } from '@/components/ui/sidebar';
 
@@ -8,15 +9,17 @@ import { ChatHistory } from './chat-history/chat-history';
 
 export function AppSidebar() {
   return (
-    <Sidebar>
-      <AppSidebarHeader />
-      <SidebarSeparator className="mt-1" />
-      <SidebarContent>
-        <ChatFolders />
-        <SidebarSeparator />
-        <ChatHistory />
-      </SidebarContent>
-      <SidebarFooter />
-    </Sidebar>
+    <DndContext>
+      <Sidebar>
+        <AppSidebarHeader />
+        <SidebarSeparator className="mt-1" />
+        <SidebarContent>
+          <ChatFolders />
+          <SidebarSeparator />
+          <ChatHistory />
+        </SidebarContent>
+        <SidebarFooter />
+      </Sidebar>
+    </DndContext>
   );
 }

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
@@ -1,16 +1,41 @@
 'use client';
-import { DndContext } from '@dnd-kit/core';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import React, { useState } from 'react';
+import { toast } from 'sonner';
 
 import { Sidebar, SidebarContent, SidebarFooter, SidebarSeparator } from '@/components/ui/sidebar';
+import { useEditChatSession } from '@/hooks/chat/use-edit-chat-session';
 
 import { AppSidebarHeader } from './app-sidebar-header';
 import { ChatFolders } from './chat-folders/chat-folders';
 import { ChatHistory } from './chat-history/chat-history';
 
 export function AppSidebar() {
+  const [, setIsDropped] = useState(false);
+  const { mutate } = useEditChatSession();
+
+  function handleDragEnd(event: DragEndEvent) {
+    if (event.over) {
+      setIsDropped(true);
+      mutate(
+        { chatSessionId: `${event.active.id}`, data: { folder_id: `${event.over.id}` } },
+        {
+          onSuccess() {
+            toast.success('Move chat successfully!');
+          },
+          onError() {
+            toast.error('Move chat failed.', {
+              description: "There's something wrong with your request. Please try again later!",
+            });
+          },
+        },
+      );
+    }
+  }
+
   return (
-    <DndContext modifiers={[restrictToVerticalAxis]}>
+    <DndContext modifiers={[restrictToVerticalAxis]} onDragEnd={handleDragEnd}>
       <Sidebar>
         <AppSidebarHeader />
         <SidebarSeparator className="mt-1" />

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
@@ -1,51 +1,26 @@
 'use client';
-import { DndContext, DragEndEvent } from '@dnd-kit/core';
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
-import React, { useState } from 'react';
-import { toast } from 'sonner';
+import React from 'react';
 
 import { Sidebar, SidebarContent, SidebarFooter, SidebarSeparator } from '@/components/ui/sidebar';
-import { useEditChatSession } from '@/hooks/chat/use-edit-chat-session';
+import DndContextProvider from '@/providers/drag-n-drop-provider';
 
 import { AppSidebarHeader } from './app-sidebar-header';
 import { ChatFolders } from './chat-folders/chat-folders';
 import { ChatHistory } from './chat-history/chat-history';
 
 export function AppSidebar() {
-  const [, setIsDropped] = useState(false);
-  const { mutate } = useEditChatSession();
-
-  function handleDragEnd(event: DragEndEvent) {
-    if (event.over) {
-      setIsDropped(true);
-      mutate(
-        { chatSessionId: `${event.active.id}`, data: { folder_id: `${event.over.id}` } },
-        {
-          onSuccess() {
-            toast.success('Move chat successfully!');
-          },
-          onError() {
-            toast.error('Move chat failed.', {
-              description: "There's something wrong with your request. Please try again later!",
-            });
-          },
-        },
-      );
-    }
-  }
-
   return (
-    <DndContext modifiers={[restrictToVerticalAxis]} onDragEnd={handleDragEnd}>
-      <Sidebar>
-        <AppSidebarHeader />
-        <SidebarSeparator className="mt-1" />
+    <Sidebar>
+      <AppSidebarHeader />
+      <SidebarSeparator className="mt-1" />
+      <DndContextProvider>
         <SidebarContent>
           <ChatFolders />
           <SidebarSeparator />
           <ChatHistory />
         </SidebarContent>
-        <SidebarFooter />
-      </Sidebar>
-    </DndContext>
+      </DndContextProvider>
+      <SidebarFooter />
+    </Sidebar>
   );
 }

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/app-sidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { DndContext } from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 
 import { Sidebar, SidebarContent, SidebarFooter, SidebarSeparator } from '@/components/ui/sidebar';
 
@@ -9,7 +10,7 @@ import { ChatHistory } from './chat-history/chat-history';
 
 export function AppSidebar() {
   return (
-    <DndContext>
+    <DndContext modifiers={[restrictToVerticalAxis]}>
       <Sidebar>
         <AppSidebarHeader />
         <SidebarSeparator className="mt-1" />

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-folders/chat-folder-item.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-folders/chat-folder-item.tsx
@@ -22,7 +22,6 @@ export const ChatFolderItem: FC<IChatFolderItemProps> = ({ folder, chatSessions,
   });
   const style = {
     backgroundColor: isOver ? 'rgba(170, 255, 170, 0.2)' : undefined,
-    zIndex: isOver ? 997 : undefined, // Make the folder float on top, but below the dragged item
   };
 
   return (

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-folders/chat-folder-item.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-folders/chat-folder-item.tsx
@@ -1,3 +1,4 @@
+import { useDroppable } from '@dnd-kit/core';
 import { FC, useState } from 'react';
 
 import ChatSessionItem from '@/components/chat-session-item/chat-session-item';
@@ -16,9 +17,17 @@ interface IChatFolderItemProps {
 
 export const ChatFolderItem: FC<IChatFolderItemProps> = ({ folder, chatSessions, isDefaultOpen }) => {
   const [isFolderOpen, setIsFolderOpen] = useState<boolean>(!!isDefaultOpen);
+  const { isOver, setNodeRef } = useDroppable({
+    id: folder.id,
+  });
+  const style = {
+    backgroundColor: isOver ? 'rgba(0, 0, 0, 0.1)' : undefined,
+  };
 
   return (
     <Collapsible
+      ref={setNodeRef}
+      style={style}
       defaultOpen={isDefaultOpen}
       className={cn('group/collapsible')}
       open={isFolderOpen}

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-folders/chat-folder-item.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-folders/chat-folder-item.tsx
@@ -21,7 +21,8 @@ export const ChatFolderItem: FC<IChatFolderItemProps> = ({ folder, chatSessions,
     id: folder.id,
   });
   const style = {
-    backgroundColor: isOver ? 'rgba(0, 0, 0, 0.1)' : undefined,
+    backgroundColor: isOver ? 'rgba(170, 255, 170, 0.2)' : undefined,
+    zIndex: isOver ? 997 : undefined, // Make the folder float on top, but below the dragged item
   };
 
   return (

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-history/chat-history.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-history/chat-history.tsx
@@ -3,6 +3,7 @@ import { FC, useMemo } from 'react';
 
 import ChatSessionItem from '@/components/chat-session-item/chat-session-item';
 import { SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarMenu } from '@/components/ui/sidebar';
+import { SIDEBAR_CHAT_HISTORY } from '@/constants/sidebar-items';
 import { useGetAllChatSessions } from '@/hooks/chat/use-get-all-chat-sessions';
 import { groupChatSessions } from '@/utils/group-chat-sessions';
 
@@ -14,7 +15,7 @@ export const ChatHistory: FC = () => {
     [chatSessions],
   );
   const { isOver, setNodeRef } = useDroppable({
-    id: 'chat-history',
+    id: SIDEBAR_CHAT_HISTORY,
   });
   const style = {
     color: isOver ? 'green' : undefined,

--- a/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-history/chat-history.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/app-sidebar/chat-history/chat-history.tsx
@@ -1,3 +1,4 @@
+import { useDroppable } from '@dnd-kit/core';
 import { FC, useMemo } from 'react';
 
 import ChatSessionItem from '@/components/chat-session-item/chat-session-item';
@@ -12,22 +13,29 @@ export const ChatHistory: FC = () => {
     () => (chatSessions ? groupChatSessions(chatSessions.filter(session => !session.folder_id)) : undefined),
     [chatSessions],
   );
-
+  const { isOver, setNodeRef } = useDroppable({
+    id: 'chat-history',
+  });
+  const style = {
+    color: isOver ? 'green' : undefined,
+  };
   return (
     <>
-      <h3 className="text-xs font-bold text-zinc-600 ml-4 mt-2">History</h3>
-      {groupedChatSessions?.map(group => (
-        <SidebarGroup key={group.title}>
-          <SidebarGroupLabel>{group.title}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {group.chatSessions.map(chatSession => (
-                <ChatSessionItem key={chatSession.id} chatSession={chatSession} />
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      ))}
+      <div ref={setNodeRef} style={style}>
+        <h3 className="text-xs font-bold text-zinc-600 ml-4 mt-2">History</h3>
+        {groupedChatSessions?.map(group => (
+          <SidebarGroup key={group.title}>
+            <SidebarGroupLabel>{group.title}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {group.chatSessions.map(chatSession => (
+                  <ChatSessionItem key={chatSession.id} chatSession={chatSession} />
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
+      </div>
     </>
   );
 };

--- a/chatbot-core/frontend/yarn.lock
+++ b/chatbot-core/frontend/yarn.lock
@@ -219,6 +219,14 @@
     "@dnd-kit/utilities" "^3.2.2"
     tslib "^2.0.0"
 
+"@dnd-kit/modifiers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz#96a0280c77b10c716ef79d9792ce7ad04370771d"
+  integrity sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
 "@dnd-kit/utilities@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
@@ -1658,6 +1666,11 @@ dnd-core@^16.0.1:
     "@react-dnd/asap" "^5.0.1"
     "@react-dnd/invariant" "^4.0.1"
     redux "^4.2.0"
+
+dnd-kit@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/dnd-kit/-/dnd-kit-0.0.2.tgz#97b849ee10ab9b4e3304af517356c6400f2b4b5d"
+  integrity sha512-d8AYd6I7D2b5u882+QNVGw0slBAt851/LWZ2j/pU+onf5/TGEKXeb47sCyhPYKEAUXp4oLfvWfNCqfkU03R1lw==
 
 doctrine@^2.1.0:
   version "2.1.0"

--- a/chatbot-core/frontend/yarn.lock
+++ b/chatbot-core/frontend/yarn.lock
@@ -21,13 +21,6 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
-"@babel/runtime@^7.9.2":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
-  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@commitlint/cli@^19.6.1":
   version "19.6.1"
   resolved "https://registry.npmjs.org/@commitlint/cli/-/cli-19.6.1.tgz"
@@ -810,21 +803,6 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
-
-"@react-dnd/asap@^5.0.1":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
-  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
-
-"@react-dnd/invariant@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
-  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
-
-"@react-dnd/shallowequal@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
-  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -1658,15 +1636,6 @@ dlv@^1.1.3:
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
-dnd-core@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
-  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
-  dependencies:
-    "@react-dnd/asap" "^5.0.1"
-    "@react-dnd/invariant" "^4.0.1"
-    redux "^4.2.0"
-
 dnd-kit@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/dnd-kit/-/dnd-kit-0.0.2.tgz#97b849ee10ab9b4e3304af517356c6400f2b4b5d"
@@ -2488,13 +2457,6 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
-
-hoist-non-react-statics@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
 
 html-tags@^3.3.1:
   version "3.3.1"
@@ -3516,24 +3478,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-dnd-html5-backend@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
-  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
-  dependencies:
-    dnd-core "^16.0.1"
-
-react-dnd@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
-  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
-  dependencies:
-    "@react-dnd/invariant" "^4.0.1"
-    "@react-dnd/shallowequal" "^4.0.1"
-    dnd-core "^16.0.1"
-    fast-deep-equal "^3.1.3"
-    hoist-non-react-statics "^3.3.2"
-
 react-dom@^18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
@@ -3556,7 +3500,7 @@ react-hook-form@^7.54.2:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
   integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3622,13 +3566,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-redux@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
-  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.8, reflect.getprototypeof@^1.0.9:
   version "1.0.9"
   resolved "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.9.tgz"
@@ -3642,11 +3579,6 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.8, reflect.getprototy
     get-intrinsic "^1.2.6"
     gopd "^1.2.0"
     which-builtin-type "^1.2.1"
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp.prototype.flags@^1.5.3:
   version "1.5.3"

--- a/chatbot-core/frontend/yarn.lock
+++ b/chatbot-core/frontend/yarn.lock
@@ -21,6 +21,13 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
+"@babel/runtime@^7.9.2":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@commitlint/cli@^19.6.1":
   version "19.6.1"
   resolved "https://registry.npmjs.org/@commitlint/cli/-/cli-19.6.1.tgz"
@@ -772,6 +779,21 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
+
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -1605,6 +1627,15 @@ dlv@^1.1.3:
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz"
@@ -2421,6 +2452,13 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 html-tags@^3.3.1:
   version "3.3.1"
@@ -3442,6 +3480,24 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-dom@^18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
@@ -3464,7 +3520,7 @@ react-hook-form@^7.54.2:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
   integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3530,6 +3586,13 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.8, reflect.getprototypeof@^1.0.9:
   version "1.0.9"
   resolved "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.9.tgz"
@@ -3543,6 +3606,11 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.8, reflect.getprototy
     get-intrinsic "^1.2.6"
     gopd "^1.2.0"
     which-builtin-type "^1.2.1"
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp.prototype.flags@^1.5.3:
   version "1.5.3"

--- a/chatbot-core/frontend/yarn.lock
+++ b/chatbot-core/frontend/yarn.lock
@@ -203,6 +203,29 @@
   resolved "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz"
   integrity sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@dual-bundle/import-meta-resolve@^4.1.0":
   version "4.1.0"
   resolved "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz"


### PR DESCRIPTION
## Description

Add drag-and-drop feature to organize chat sessions and chat folders.

- Drag from chat history to folders (add to folder)
- Drag from folder to folders (change folder)
- Drag from folder to chat history (remove from folder)

## How Has This Been Tested?

Built with docker.

## Accepted Risk

None

## Related Issue(s)

#202 

## Checklist:

- [ ] Author has done a final read through of the PR right before merge
- [ ] All tests passed
- [ ] Code review
- [ ] (Optional) If there are migrations, they have been rebased to latest main
- [ ] (Optional) If there are new dependencies, they are added to the requirements
- [ ] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [ ] (Optional) Docker images build and basic functionalities work
