### PR TITLE
refactor(docker): remove complex network in dev docker compose

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yaml
+++ b/deployment/docker_compose/docker-compose.dev.yaml
@@ -20,7 +20,7 @@ services:
       - mssql_log_volume:/var/opt/mssql/log
       - mssql_backup_volume:/var/opt/mssql/backup
     networks:
-      - backend
+      - chatbot-core
     healthcheck:
       test:
         [
@@ -50,7 +50,7 @@ services:
       database:
         condition: service_healthy
     networks:
-      - backend
+      - chatbot-core
     command: >
       /bin/bash -c "/opt/mssql-tools18/bin/sqlcmd -S database -U $$MSSQL_USER -P $$MSSQL_SA_PASSWORD -d master -C -i /docker-entrypoint-initdb.d/init.sql &&
       echo 'Database configured!'"
@@ -63,7 +63,7 @@ services:
     ports:
       - "6379:6379"
     networks:
-      - backend
+      - chatbot-core
     # docker silently mounts /data even without an explicit volume mount, which enables
     # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
@@ -95,7 +95,7 @@ services:
     volumes:
       - qdrant_data_volume:/qdrant/storage
     networks:
-      - backend
+      - chatbot-core
     healthcheck:
       test: curl -s http://localhost:6333/healthz | grep -q 'healthz check passed' || exit 1
       interval: 10s
@@ -117,7 +117,7 @@ services:
     volumes:
       - minio_data:/data
     networks:
-      - backend
+      - chatbot-core
     command: server --console-address ":9001" /data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
@@ -162,7 +162,7 @@ services:
       - ../../chatbot-core/backend/app/:/app/app
       - ../../chatbot-core/backend/tests/:/app/tests
     networks:
-      - backend
+      - chatbot-core
     extra_hosts:
       - "host.docker.internal:host-gateway"
     logging:
@@ -190,8 +190,7 @@ services:
       - ../data/nginx:/etc/nginx/conf.d
       - /app/node_modules # Avoid node_modules conflicts
     networks:
-      - frontend
-      - backend
+      - chatbot-core
     #INFO: require 2 env files
     # 1) .env file located in deployment/docker_compose
     # 2) .env/.env.development/.env.production file located in chatbot-core
@@ -218,9 +217,7 @@ volumes:
   minio_data:
 
 networks:
-  backend:
-    driver: bridge
-  frontend:
+  chatbot-core:
     driver: bridge
 
 configs:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Current docker compose under development `docker-compose.dev.yaml` has a network layer that separates `backend` and `frontend`, which is too complex.

This PR is to remove that, and use 1 default network instead.

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

```
make down
make up
```

## Accepted Risk

<!-- Any know risks or failure modes to point out to reviewers -->

## Related Issue(s)

<!-- If applicable, link to the issue(s) this PR addresses -->

## Checklist:

- [x] Author has done a final read through of the PR right before merge
- [x] All tests passed
- [ ] Code review
- [x] (Optional) If there are migrations, they have been rebased to latest main
- [x] (Optional) If there are new dependencies, they are added to the requirements
- [x] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [x] (Optional) Docker images build and basic functionalities work
