### PR TITLE
fix(frontend): wrong types for chat store

### DIFF
--- a/chatbot-core/frontend/src/views/main-layout/chat-box/chat-box.tsx
+++ b/chatbot-core/frontend/src/views/main-layout/chat-box/chat-box.tsx
@@ -4,12 +4,12 @@ import { useIsMutating } from '@tanstack/react-query';
 import { ArrowUpIcon, PlusCircle, Search, Square } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { QueryParams, SupportedKeys } from '@/constants/misc';
 import { ReactMutationKey } from '@/constants/react-query-key';
 import { useNewChatHelper } from '@/hooks/chat/use-new-chat-helper';
+import { useChatStore } from '@/hooks/stores/use-chat-store';
 
 import { AutoHeightTextarea } from './auto-height-textarea/auto-height-textarea';
 
@@ -29,6 +29,7 @@ export const ChatBox = () => {
     },
     disabled: !!isCreatingMessage,
   });
+  const cancelStream = useChatStore(state => state.cancelStream);
 
   const onButtonClick = () => {
     if (!isCreatingMessage) {
@@ -36,8 +37,9 @@ export const ChatBox = () => {
       return;
     }
 
-    // Implement aborting chat here
-    toast.info('This feature will be supported in the future.');
+    if (chatSessionId) {
+      cancelStream(chatSessionId);
+    }
   };
 
   return (


### PR DESCRIPTION
## Description

This PR fixes the type from `useChatStore`. Previously, when implementing, I set the type of the `chatSessionItem` can be undefined, which lead to error.

## How Has This Been Tested?

Build on local machine.

## Accepted Risk

No risks.

## Checklist:

- [ ] Author has done a final read through of the PR right before merge
- [ ] All tests passed
- [ ] Code review
- [ ] (Optional) If there are migrations, they have been rebased to latest main
- [ ] (Optional) If there are new dependencies, they are added to the requirements
- [ ] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [ ] (Optional) Docker images build and basic functionalities work
