### PR TITLE
fix(backend): update field updated_at of table chat_session when new chat message is inserted

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yaml
+++ b/deployment/docker_compose/docker-compose.dev.yaml
@@ -172,42 +172,42 @@ services:
         max-file: "6"
 
   # NOTE: Official port for web-server is 3000
-  # web-server:
-  #   build:
-  #     context: ../../chatbot-core/frontend
-  #     dockerfile: Dockerfile
-  #   platform: linux/amd64
-  #   container_name: web-server
-  #   hostname: web-server
-  #   restart: on-failure
-  #   depends_on:
-  #     - api-server
-  #   environment:
-  #     - DOMAIN=localhost
-  #   ports:
-  #     - "3000:80"
-  #   volumes:
-  #     - ../data/nginx:/etc/nginx/conf.d
-  #     - /app/node_modules # Avoid node_modules conflicts
-  #   networks:
-  #     - chatbot-core
-  #   #INFO: require 2 env files
-  #   # 1) .env file located in deployment/docker_compose
-  #   # 2) .env/.env.development/.env.production file located in chatbot-core
-  #   # The first file store general variables for both projects, the second file store project-specific variables for chatbot-core
-  #   # WARN: cannot start this service without both files
-  #   env_file:
-  #     - ./.env
-  #     - ../../chatbot-core/${ENV_FILE:-.env} # default to .env
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   command: >
-  #     /bin/sh -c "chmod +x /etc/nginx/conf.d/run-nginx.sh
-  #     && dos2unix /etc/nginx/conf.d/run-nginx.sh
-  #     && /etc/nginx/conf.d/run-nginx.sh app.conf.template.dev"
+  web-server:
+    build:
+      context: ../../chatbot-core/frontend
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: web-server
+    hostname: web-server
+    restart: on-failure
+    depends_on:
+      - api-server
+    environment:
+      - DOMAIN=localhost
+    ports:
+      - "3000:80"
+    volumes:
+      - ../data/nginx:/etc/nginx/conf.d
+      - /app/node_modules # Avoid node_modules conflicts
+    networks:
+      - chatbot-core
+    #INFO: require 2 env files
+    # 1) .env file located in deployment/docker_compose
+    # 2) .env/.env.development/.env.production file located in chatbot-core
+    # The first file store general variables for both projects, the second file store project-specific variables for chatbot-core
+    # WARN: cannot start this service without both files
+    env_file:
+      - ./.env
+      - ../../chatbot-core/${ENV_FILE:-.env} # default to .env
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+    command: >
+      /bin/sh -c "chmod +x /etc/nginx/conf.d/run-nginx.sh
+      && dos2unix /etc/nginx/conf.d/run-nginx.sh
+      && /etc/nginx/conf.d/run-nginx.sh app.conf.template.dev"
 
 volumes:
   mssql_data_volume:

--- a/deployment/docker_compose/docker-compose.dev.yaml
+++ b/deployment/docker_compose/docker-compose.dev.yaml
@@ -172,42 +172,42 @@ services:
         max-file: "6"
 
   # NOTE: Official port for web-server is 3000
-  web-server:
-    build:
-      context: ../../chatbot-core/frontend
-      dockerfile: Dockerfile
-    platform: linux/amd64
-    container_name: web-server
-    hostname: web-server
-    restart: on-failure
-    depends_on:
-      - api-server
-    environment:
-      - DOMAIN=localhost
-    ports:
-      - "3000:80"
-    volumes:
-      - ../data/nginx:/etc/nginx/conf.d
-      - /app/node_modules # Avoid node_modules conflicts
-    networks:
-      - chatbot-core
-    #INFO: require 2 env files
-    # 1) .env file located in deployment/docker_compose
-    # 2) .env/.env.development/.env.production file located in chatbot-core
-    # The first file store general variables for both projects, the second file store project-specific variables for chatbot-core
-    # WARN: cannot start this service without both files
-    env_file:
-      - ./.env
-      - ../../chatbot-core/${ENV_FILE:-.env} # default to .env
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-    command: >
-      /bin/sh -c "chmod +x /etc/nginx/conf.d/run-nginx.sh
-      && dos2unix /etc/nginx/conf.d/run-nginx.sh
-      && /etc/nginx/conf.d/run-nginx.sh app.conf.template.dev"
+  # web-server:
+  #   build:
+  #     context: ../../chatbot-core/frontend
+  #     dockerfile: Dockerfile
+  #   platform: linux/amd64
+  #   container_name: web-server
+  #   hostname: web-server
+  #   restart: on-failure
+  #   depends_on:
+  #     - api-server
+  #   environment:
+  #     - DOMAIN=localhost
+  #   ports:
+  #     - "3000:80"
+  #   volumes:
+  #     - ../data/nginx:/etc/nginx/conf.d
+  #     - /app/node_modules # Avoid node_modules conflicts
+  #   networks:
+  #     - chatbot-core
+  #   #INFO: require 2 env files
+  #   # 1) .env file located in deployment/docker_compose
+  #   # 2) .env/.env.development/.env.production file located in chatbot-core
+  #   # The first file store general variables for both projects, the second file store project-specific variables for chatbot-core
+  #   # WARN: cannot start this service without both files
+  #   env_file:
+  #     - ./.env
+  #     - ../../chatbot-core/${ENV_FILE:-.env} # default to .env
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
+  #   command: >
+  #     /bin/sh -c "chmod +x /etc/nginx/conf.d/run-nginx.sh
+  #     && dos2unix /etc/nginx/conf.d/run-nginx.sh
+  #     && /etc/nginx/conf.d/run-nginx.sh app.conf.template.dev"
 
 volumes:
   mssql_data_volume:


### PR DESCRIPTION
The chatbot system consists of two related tables: chat_session (one) and chat_message (many). Each chat session can have multiple chat messages associated with it. However, when a new message is inserted into the chat_message table, the corresponding updated_at field in the chat_session table is not being updated as expected. This causes issues in tracking active conversations and session timestamps.

**Solution**: Use SQLAlchemy Event Listener `after_insert`. For more details, visit [here](https://docs.sqlalchemy.org/en/20/orm/events.html).