### PR TITLE
fix(frontend): change method cancel sse from stream.cancel to abortController

### DIFF
--- a/chatbot-core/frontend/src/hooks/stores/use-chat-store.ts
+++ b/chatbot-core/frontend/src/hooks/stores/use-chat-store.ts
@@ -10,7 +10,7 @@ interface IChatStore {
       messages: IChatMessageResponse[];
       streamState: StreamingMessageState;
       streamingMessage: string;
-      streamReader: ReadableStreamDefaultReader<string> | null;
+      abortController: AbortController | null;
     };
   };
 
@@ -18,7 +18,7 @@ interface IChatStore {
   addMessage(chatSessionId: string, message: IChatMessageResponse): void;
   setStreamState(chatSessionId: string, streamState: StreamingMessageState): void;
   setStreamingMessage(chatSessionId: string, messageChunk: string): void;
-  setStreamReader(chatSessionId: string, streamReader: ReadableStreamDefaultReader<string> | null): void;
+  setStreamAbortController(chatSessionId: string, abortController: AbortController | null): void;
   cancelStream(chatSessionId: string): void;
 
   setUserMessage(message: string): void;
@@ -47,7 +47,7 @@ export const useChatStore = create<IChatStore>((set, get) => ({
       messages: [],
       streamState: StreamingMessageState.IDLE,
       streamingMessage: '',
-      streamReader: null,
+      abortController: null,
     };
 
     set({ chatSession });
@@ -87,27 +87,27 @@ export const useChatStore = create<IChatStore>((set, get) => ({
 
     set({ chatSession });
   },
-  setStreamReader(chatSessionId, streamReader) {
+  setStreamAbortController(chatSessionId, abortController) {
     const { chatSession } = get();
 
     if (!chatSession[chatSessionId]) {
       throw new Error();
     }
 
-    chatSession[chatSessionId].streamReader = streamReader;
+    chatSession[chatSessionId].abortController = abortController;
 
     set({ chatSession });
   },
   cancelStream(chatSessionId) {
     const { chatSession } = get();
-    const streamReader = chatSession[chatSessionId].streamReader;
+    const abortController = chatSession[chatSessionId].abortController;
 
-    if (!chatSession[chatSessionId] || !streamReader) {
+    if (!chatSession[chatSessionId] || !abortController) {
       throw new Error();
     }
 
-    streamReader.cancel();
-    chatSession[chatSessionId].streamReader = null;
+    abortController.abort();
+    chatSession[chatSessionId].abortController = null;
 
     set({ chatSession });
   },

--- a/chatbot-core/frontend/src/services/chat/create-chat-message.ts
+++ b/chatbot-core/frontend/src/services/chat/create-chat-message.ts
@@ -5,13 +5,21 @@ import { ApiEndpointPrefix, getApiUrl } from '@/utils/get-api-url';
 interface ICreateChatMessageProps {
   chatSessionId: string;
   data: Partial<IChatMessageRequest>;
+  abortController: AbortController;
 }
 
-export const createChatMessage = async ({ chatSessionId, data }: ICreateChatMessageProps): Promise<ReadableStream> => {
+export const createChatMessage = async ({
+  chatSessionId,
+  data,
+  abortController,
+}: ICreateChatMessageProps): Promise<ReadableStream> => {
   try {
     const res = await streamClient.post<ReadableStream>(
       getApiUrl(ApiEndpointPrefix.CHAT, `/chat-sessions/${chatSessionId}/messages`),
       data,
+      {
+        signal: abortController.signal,
+      },
     );
 
     return res.data;


### PR DESCRIPTION
## Description

When implementing cancel sse functionality, previously, I used the `reader.cancel()`, which is a method from `ReadableStreamDefaultReader`. This function is used to stop receiving sse from server. However, it only stops receiving, not notifies the server that user doesn't want to receive the sse anymore. Therefore, I migrated it to using `AbortController`, which is used to stop a request from client to server.

## How Has This Been Tested?

Tested successfully on local machine.

## Accepted Risk

No risks.

## Checklist:

- [x] Author has done a final read through of the PR right before merge
- [x] All tests passed
- [x] Code review
- [ ] (Optional) If there are migrations, they have been rebased to latest main
- [ ] (Optional) If there are new dependencies, they are added to the requirements
- [ ] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [ ] (Optional) Docker images build and basic functionalities work
