### PR TITLE
fix(frontend): add message to client state after aborting

### DIFF
--- a/chatbot-core/frontend/src/hooks/chat/use-create-chat-message.ts
+++ b/chatbot-core/frontend/src/hooks/chat/use-create-chat-message.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { ReactMutationKey } from '@/constants/react-query-key';
 import { createChatMessage } from '@/services/chat/create-chat-message';
 import { ChatMessageStreamEvent, ChatMessageType, StreamingMessageState } from '@/types/chat';
+import { checkAbortError } from '@/utils/check-error';
 import { decodeChatStreamChunk } from '@/utils/decode-chat-stream-chunk';
 
 import { useChatStore } from '../stores/use-chat-store';
@@ -22,59 +23,61 @@ export const useCreateChatMessage = ({ chatSessionId }: IUseCreateChatMessagePro
   return useMutation({
     mutationKey: [ReactMutationKey.CREATE_CHAT_MESSAGE, chatSessionId],
     mutationFn: async (props: Omit<ChatMessageRequest, 'abortController'>) => {
-      const abortController = new AbortController();
-      const stream = await createChatMessage({ ...props, abortController });
-      const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
-      setStreamAbortController(props.chatSessionId, abortController);
-
       let fullResponse = '';
-      let isCompleteMessage = false;
 
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) {
-          if (!isCompleteMessage) {
-            addChatMessage(props.chatSessionId, {
-              id: window.crypto.randomUUID(),
-              message: fullResponse,
-              chat_session_id: props.chatSessionId,
-              message_type: ChatMessageType.ASSISTANT,
-              is_sensitive: false,
-              created_at: new Date().toLocaleDateString(),
-              updated_at: new Date().toLocaleDateString(),
-              deleted_at: null,
-            });
+      try {
+        const abortController = new AbortController();
+        const stream = await createChatMessage({ ...props, abortController });
+        const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
+        setStreamAbortController(props.chatSessionId, abortController);
+
+        while (true) {
+          const { value, done } = await reader.read();
+
+          if (done) {
+            break;
           }
 
-          break;
+          const { event, data } = decodeChatStreamChunk(value);
+
+          switch (event) {
+            case ChatMessageStreamEvent.METADATA:
+              addChatMessage(props.chatSessionId, data);
+              setStreamState(props.chatSessionId, StreamingMessageState.PENDING);
+              break;
+            case ChatMessageStreamEvent.DELTA:
+              if (!fullResponse) {
+                setStreamState(props.chatSessionId, StreamingMessageState.STREAMING);
+              }
+
+              const newChunk = data;
+              fullResponse += newChunk;
+              setStreamingMessage(props.chatSessionId, fullResponse);
+              break;
+            case ChatMessageStreamEvent.STREAM_COMPLETE:
+              const serverChatResponse = {
+                ...data,
+                message: fullResponse,
+              };
+              addChatMessage(props.chatSessionId, serverChatResponse);
+              setStreamState(props.chatSessionId, StreamingMessageState.IDLE);
+              break;
+          }
         }
-
-        const { event, data } = decodeChatStreamChunk(value);
-
-        switch (event) {
-          case ChatMessageStreamEvent.METADATA:
-            addChatMessage(props.chatSessionId, data);
-            setStreamState(props.chatSessionId, StreamingMessageState.PENDING);
-            break;
-          case ChatMessageStreamEvent.DELTA:
-            if (!fullResponse) {
-              setStreamState(props.chatSessionId, StreamingMessageState.STREAMING);
-            }
-
-            const newChunk = data;
-            fullResponse += newChunk;
-            setStreamingMessage(props.chatSessionId, fullResponse);
-            break;
-          case ChatMessageStreamEvent.STREAM_COMPLETE:
-            const serverChatResponse = {
-              ...data,
-              message: fullResponse,
-            };
-            addChatMessage(props.chatSessionId, serverChatResponse);
-            setStreamState(props.chatSessionId, StreamingMessageState.IDLE);
-            isCompleteMessage = true;
-            break;
+      } catch (error) {
+        if (checkAbortError(error)) {
+          addChatMessage(props.chatSessionId, {
+            id: window.crypto.randomUUID(),
+            message: fullResponse,
+            chat_session_id: props.chatSessionId,
+            message_type: ChatMessageType.ASSISTANT,
+            is_sensitive: false,
+            created_at: new Date().toLocaleDateString(),
+            updated_at: new Date().toLocaleDateString(),
+            deleted_at: null,
+          });
         }
+        throw error;
       }
     },
     onSettled(_, __, variables) {

--- a/chatbot-core/frontend/src/utils/check-error.ts
+++ b/chatbot-core/frontend/src/utils/check-error.ts
@@ -1,0 +1,5 @@
+const ABORT_ERROR_NAME = 'AbortError';
+
+export function checkAbortError(error: unknown): error is DOMException {
+  return error instanceof DOMException && error.name === ABORT_ERROR_NAME;
+}


### PR DESCRIPTION
## Description

When implementing the cancel sse, in the previous version, I use `cancel` method from `ReadableStreamDefaultReader`, and to detect if it is cancelled, I use the `done` value to check, but this is not applicable for the abort. Instead, I am using try catch block to detect abort error.

## How Has This Been Tested?

Tested successfully on local machine.

## Accepted Risk

No risks.

## Checklist:

- [x] Author has done a final read through of the PR right before merge
- [x] All tests passed
- [x] Code review
- [ ] (Optional) If there are migrations, they have been rebased to latest main
- [ ] (Optional) If there are new dependencies, they are added to the requirements
- [ ] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [ ] (Optional) Docker images build and basic functionalities work
