### PR TITLE
fix(backend): fix sqlalchemy type for storing vietnamese text with accents

### DIFF
--- a/chatbot-core/backend/alembic/versions/c48653da954b_modify_column_type_for_storing_vietnamese_text.py
+++ b/chatbot-core/backend/alembic/versions/c48653da954b_modify_column_type_for_storing_vietnamese_text.py
@@ -24,9 +24,8 @@ def upgrade() -> None:
     op.alter_column(
         "chat_session",
         "description",
-        existing_type=sa.VARCHAR(length=255, collation="SQL_Latin1_General_CP1_CI_AS"),
-        type_=sa.NVARCHAR(),
-        nullable=True,
+        existing_type=sa.NVARCHAR(collation="SQL_Latin1_General_CP1_CI_AS"),
+        type_=sa.NVARCHAR(length=255),
         existing_nullable=True,
     )
     op.alter_column(
@@ -40,9 +39,8 @@ def upgrade() -> None:
     op.alter_column(
         "user",
         "name",
-        existing_type=sa.VARCHAR(length=255, collation="SQL_Latin1_General_CP1_CI_AS"),
-        type_=sa.NVARCHAR(),
-        nullable=True,
+        existing_type=sa.NVARCHAR(collation="SQL_Latin1_General_CP1_CI_AS"),
+        type_=sa.NVARCHAR(length=255),
         existing_nullable=True,
     )
     # ### end Alembic commands ###
@@ -53,9 +51,8 @@ def downgrade() -> None:
     op.alter_column(
         "chat_session",
         "description",
-        existing_type=sa.NVARCHAR(),
-        type_=sa.VARCHAR(length=255, collation="SQL_Latin1_General_CP1_CI_AS"),
-        nullable=True,
+        existing_type=sa.NVARCHAR(length=255),
+        type_=sa.NVARCHAR(collation="SQL_Latin1_General_CP1_CI_AS"),
         existing_nullable=True,
     )
     op.alter_column(
@@ -69,9 +66,8 @@ def downgrade() -> None:
     op.alter_column(
         "user",
         "name",
-        existing_type=sa.NVARCHAR(),
-        type_=sa.VARCHAR(length=255, collation="SQL_Latin1_General_CP1_CI_AS"),
-        nullable=True,
+        existing_type=sa.NVARCHAR(length=255),
+        type_=sa.NVARCHAR(collation="SQL_Latin1_General_CP1_CI_AS"),
         existing_nullable=True,
     )
     # ### end Alembic commands ###


### PR DESCRIPTION
The chatbot system stores text data in a database using SQLAlchemy. However, the current data type (e.g., String, Text) does not properly support storing Vietnamese text with accents. This results in incorrect storage and retrieval, where characters like "bằng" are saved as "b?ang". To resolve this, we need to update the data type to NVARCHAR, which fully supports Unicode characters, including Vietnamese diacritics.

**Solution**: Change the SQLAlchemy string-based columns to use `NVARCHAR` type.

**Step to get those updates**:
1. Use DataGrip / Dbeaver to access the database.
2. Update column `version_num` of table `alembic_version` to `4dd998601576`.
3. Run the command `make alembic-upgrade-head` in the directory `chatbot/chatbot-core`.

**If you find any problem with alembic**:
1. Drop the database `chatbot-core`.
2. Restart the `api-server` service.