### PR TITLE
feat(backend): rename chat session instead of UUID

### DIFF
--- a/chatbot-core/backend/app/main.py
+++ b/chatbot-core/backend/app/main.py
@@ -81,7 +81,9 @@ def create_app() -> FastAPI:
         description=Constants.FASTAPI_DESCRIPTION,
         lifespan=lifespan,
     )
-    origins = ["http://localhost:3000"]  # WARN: Update this to the actual frontend URL
+    origins = [
+        "http://127.0.0.1:3000",
+    ]  # WARN: Update this to the actual frontend URL
 
     app.add_middleware(
         CORSMiddleware,

--- a/chatbot-core/backend/app/models/chat.py
+++ b/chatbot-core/backend/app/models/chat.py
@@ -72,6 +72,7 @@ class ChatMessageStreamEvent(str, Enum):
     STREAM_COMPLETE = "stream_complete"
     NAMING = "naming"
     ERROR = "error"
+    END = "end"
 
 
 class ChatMessageRequestType(str, Enum):

--- a/chatbot-core/backend/app/models/chat.py
+++ b/chatbot-core/backend/app/models/chat.py
@@ -70,6 +70,7 @@ class ChatMessageStreamEvent(str, Enum):
     METADATA = "metadata"
     DELTA = "delta"
     STREAM_COMPLETE = "stream_complete"
+    NAMING = "naming"
     ERROR = "error"
 
 

--- a/chatbot-core/backend/app/models/chat.py
+++ b/chatbot-core/backend/app/models/chat.py
@@ -72,7 +72,6 @@ class ChatMessageStreamEvent(str, Enum):
     STREAM_COMPLETE = "stream_complete"
     NAMING = "naming"
     ERROR = "error"
-    END = "end"
 
 
 class ChatMessageRequestType(str, Enum):

--- a/chatbot-core/backend/app/services/chat.py
+++ b/chatbot-core/backend/app/services/chat.py
@@ -492,10 +492,10 @@ class ChatService(BaseService):
         accumulated_name = []
         try:
             response_streaming = await Settings.llm.astream_complete(prompt=prompt)
-            async for response in response_streaming:
-                accumulated_name.append(response.delta)
+            async for paritital_response in response_streaming:
+                accumulated_name.append(paritital_response.delta)
                 yield ChatStreamResponse(
-                    event=ChatMessageStreamEvent.NAMING, content=response.delta
+                    event=ChatMessageStreamEvent.NAMING, content=paritital_response.delta
                 ).as_json()
         except Exception as e:
             yield ChatStreamResponse(

--- a/chatbot-core/backend/app/services/chat.py
+++ b/chatbot-core/backend/app/services/chat.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from llama_index.core import Settings
 from llama_index.core.chat_engine import CondensePlusContextChatEngine
 from llama_index.core.types import ChatMessage as LlamaIndexChatMessage
 from sqlalchemy.orm import Session
@@ -23,77 +24,12 @@ from app.models.chat import ChatSessionRequest
 from app.models.chat import ChatStreamResponse
 from app.repositories.chat import ChatRepository
 from app.services.base import BaseService
+from app.settings import Constants
 from app.utils.api.api_response import APIError
 from app.utils.api.error_handler import ConversationError
 from app.utils.api.helpers import get_logger
 
 logger = get_logger(__name__)
-
-SYSTEM_PROMPT = """
-You are a human resources professional at a company that needs to quickly find information in its policy documents.
-
-Guidelines:
-- Provide information explicitly stated in policy documents
-- For basic contextual questions (company name, policy type, etc), use ONLY information directly visible in the provided context
-- No assumptions or interpretations about policy details
-- Do not explain
-- Your primary language is Vietnamese
-- If you cannot find an answer, please output "Không tìm thấy thông tin, hãy liên hệ HR. SĐT: 0919 397 169 (Ms. Nhã) hoặc email hr@giaiphaptinhhoa.com"
-- If the response is empty, please answer with the knowledge you have
-
-Let's work this out in a step by step way to be sure we have the right answer.
-Answer as the tone of a human resources professional, be polite and helpful."""
-
-CONTEXT_PROMPT = """
-The following is a friendly conversation between an employee and a human resources professional.
-The professional is talkative and provides lots of specific details from her context.
-If the professional does not know the answer to a question, she truthfully says she does not know.
-
-Here are the relevant documents for the context:
-'''
-{context_str}
-'''
-
-## Instruction
-Based on the above documents, provide a detailed answer for the employee question below.
-Answer "don't know" if not present in the document."""
-
-CONTEXT_REFINE_PROMPT = """
-The following is a friendly conversation between an employee and a human resources professional.
-The professional is talkative and provides lots of specific details from her context.
-If the professional does not know the answer to a question, she truthfully says she does not know.
-
-Here are the relevant documents for the context:
-'''
-{context_msg}
-'''
-
-Existing Answer:
-'''
-{existing_answer}
-'''
-
-## Instruction
-Refine the existing answer using the provided context to assist the user.
-If the context isn't helpful, just repeat the existing answer and nothing more."""
-
-CONDENSE_PROMPT = """
-Given the following conversation between an employee and a human resources professional and a follow up question from the employee.
-Your task is to firstly summarize the chat history and secondly condense the follow up question into a standalone question.
-
-Chat History:
-'''
-{chat_history}
-'''
-
-Follow Up Input:
-'''
-{question}
-'''
-
-Output format: a standalone question.
-
-Your response:"""
 
 
 class ChatService(BaseService):
@@ -335,7 +271,7 @@ class ChatService(BaseService):
         self,
         chat_message_request: ChatMessageRequest,
         chat_session_id: str,
-        current_chat_request: ChatMessage,
+        current_request_id: str,
         pre_register_chat_response: ChatMessage,
         chat_history: List[LlamaIndexChatMessage],
     ) -> AsyncGenerator[str, None, None]:
@@ -346,7 +282,7 @@ class ChatService(BaseService):
         Args:
             chat_message_request (ChatMessageRequest): Chat message request object.
             chat_session_id (str): Chat session ID.
-            current_chat_request (ChatMessage): Current chat request message.
+            current_request_id (str): Current request message ID.
             pre_register_chat_response (ChatMessage): Pre-registered chat response message.
             chat_history (List[LlamaIndexChatMessage]): The LlamaIndex chat history of the chat session.
 
@@ -373,10 +309,10 @@ class ChatService(BaseService):
             chat_engine = CondensePlusContextChatEngine.from_defaults(
                 retriever=retriever,
                 chat_history=chat_history,
-                system_prompt=SYSTEM_PROMPT,
-                context_prompt=CONTEXT_PROMPT,
-                context_refine_prompt=CONTEXT_REFINE_PROMPT,
-                condense_prompt=CONDENSE_PROMPT,
+                system_prompt=Constants.CHAT_ENGINE_SYSTEM_PROMPT,
+                context_prompt=Constants.CHAT_ENGINE_CONTEXT_PROMPT,
+                context_refine_prompt=Constants.CHAT_ENGINE_CONTEXT_PROMPT,
+                condense_prompt=Constants.CHAT_ENGINE_CONDENSE_PROMPT,
                 verbose=True,
             )
 
@@ -410,7 +346,7 @@ class ChatService(BaseService):
             # Create final response message with complete text
             if not accumulated_response:
                 logger.warning(
-                    f"No content received from agent for session {chat_session_id} for request {current_chat_request.id}"
+                    f"No content received from agent for session {chat_session_id} for request {current_request_id}"
                 )
                 yield ChatStreamResponse(
                     event=ChatMessageStreamEvent.ERROR,
@@ -420,28 +356,6 @@ class ChatService(BaseService):
             # Create final response message with complete text
             complete_response = "".join(accumulated_response) if accumulated_response else ""
             pre_register_chat_response.message = complete_response
-
-            # Name if the chat session is newly created
-            if (
-                current_chat_request.parent_message_id is None
-                and chat_message_request.request_type == ChatMessageRequestType.NEW
-            ):
-                logger.info("Chat session is newly created. Naming the chat session...")
-
-                PROMPT = f"""
-                Generate a short title (5-10 words) for the chat session based on the following conversation:
-
-                User: {current_chat_request.message}
-                Agent: {complete_response}
-                """
-
-                from llama_index.core import Settings
-
-                response_streaming = Settings.llm.stream_complete(prompt=PROMPT)
-                for response in response_streaming:
-                    yield ChatStreamResponse(
-                        event=ChatMessageStreamEvent.NAMING, content=response.text
-                    ).as_json()
 
             # Store the complete message in the database
             logger.info("Creating a new chat response message")
@@ -457,7 +371,7 @@ class ChatService(BaseService):
             self._db_session.flush()
         except Exception as e:
             logger.error(
-                f"Error generating chat response - Chat session: {chat_session_id}, Chat request: {current_chat_request.id}, Error: {e}"
+                f"Error generating chat response - Chat session: {chat_session_id}, Chat request: {current_request_id}, Error: {e}"
             )
             yield ChatStreamResponse(
                 event=ChatMessageStreamEvent.ERROR,
@@ -550,6 +464,59 @@ class ChatService(BaseService):
             return err
 
         return None
+
+    async def _handle_naming_chat_session(
+        self,
+        chat_session_id: str,
+        user_id: str,
+        chat_request_message: str = "",
+        chat_response_message: str = "",
+    ) -> AsyncGenerator[str, None, None]:
+        """
+        Handle naming chat session.
+
+        Args:
+            chat_session_id(str): Chat session id
+            user_id(str): User id
+            chat_request_message(str): Chat request message. Defaults to "".
+            chat_response_message(str): Chat response message. Defaults to "".
+
+        Returns:
+            AsyncGenerator[str, None, None]: Async generator of chat session naming response.
+        """
+        # Construct prompt
+        prompt = Constants.CHAT_SESSION_NAMING_PROMPT.format(
+            user_message=chat_request_message, agent_message=chat_response_message
+        )
+
+        accumulated_name = []
+        try:
+            response_streaming = await Settings.llm.astream_complete(prompt=prompt)
+            async for response in response_streaming:
+                accumulated_name.append(response.delta)
+                yield ChatStreamResponse(
+                    event=ChatMessageStreamEvent.NAMING, content=response.delta
+                ).as_json()
+        except Exception as e:
+            yield ChatStreamResponse(
+                event=ChatMessageStreamEvent.ERROR,
+                content=f"Error during chat session naming: {e}",
+            ).as_json()
+
+        # Finalize session name
+        final_name = "".join(accumulated_name).strip() or "Untitled Chat"
+
+        # Rename the chat session with the generated name
+        updated_chat_session = ChatSessionRequest(description=final_name).model_dump(
+            exclude_unset=True
+        )
+        if err := self._chat_repository.update_chat_session(
+            chat_session_id=chat_session_id, chat_session=updated_chat_session, user_id=user_id
+        ):
+            yield ChatStreamResponse(
+                event=ChatMessageStreamEvent.ERROR,
+                content=f"Error during chat session naming: {err}",
+            ).as_json()
 
     def _handle_existing_chat_message(
         self, chat_message_request: ChatMessageRequest, chat_session_id: str, user_id: str
@@ -701,7 +668,7 @@ class ChatService(BaseService):
             async for chunk in self._generate_chat_response(
                 chat_message_request=chat_message_request,
                 chat_session_id=chat_session_id,
-                current_chat_request=chat_request,
+                current_request_id=chat_request.id,
                 pre_register_chat_response=chat_response,
                 chat_history=chat_history,
             ):
@@ -714,6 +681,20 @@ class ChatService(BaseService):
                     mode="json", exclude={"message"}
                 ),
             ).as_json()
+
+            # Name chat session if it is newly created
+            if (
+                chat_request.parent_message_id is None
+                and chat_message_request.request_type == ChatMessageRequestType.NEW
+            ):
+                logger.info("Chat session is newly created. Naming the chat session...")
+                async for chunk in self._handle_naming_chat_session(
+                    chat_session_id=chat_session_id,
+                    user_id=user_id,
+                    chat_request_message=chat_request.message,
+                    chat_response_message=chat_response.message,
+                ):
+                    yield chunk
 
         except Exception as e:
             logger.error(f"Error handling new chat message: {e}")
@@ -813,6 +794,9 @@ class ChatService(BaseService):
                 user_id=user_id,
             ):
                 yield chunk
+
+            # End stream
+            yield ChatStreamResponse(event=ChatMessageStreamEvent.END, content="").as_json()
 
     def create_chat_feedback(
         self, chat_feedback_request: ChatFeedbackRequest

--- a/chatbot-core/backend/app/services/chat.py
+++ b/chatbot-core/backend/app/services/chat.py
@@ -492,10 +492,10 @@ class ChatService(BaseService):
         accumulated_name = []
         try:
             response_streaming = await Settings.llm.astream_complete(prompt=prompt)
-            async for paritital_response in response_streaming:
-                accumulated_name.append(paritital_response.delta)
+            async for partial_response in response_streaming:
+                accumulated_name.append(partial_response.delta)
                 yield ChatStreamResponse(
-                    event=ChatMessageStreamEvent.NAMING, content=paritital_response.delta
+                    event=ChatMessageStreamEvent.NAMING, content=partial_response.delta
                 ).as_json()
         except Exception as e:
             yield ChatStreamResponse(

--- a/chatbot-core/backend/app/services/chat.py
+++ b/chatbot-core/backend/app/services/chat.py
@@ -674,14 +674,6 @@ class ChatService(BaseService):
             ):
                 yield chunk
 
-            # Stream the chat response message object. We don't include the message content in the response.
-            yield ChatStreamResponse(
-                event=ChatMessageStreamEvent.STREAM_COMPLETE,
-                content=ChatMessageResponse.model_validate(chat_response).model_dump(
-                    mode="json", exclude={"message"}
-                ),
-            ).as_json()
-
             # Name chat session if it is newly created
             if (
                 chat_request.parent_message_id is None
@@ -695,6 +687,14 @@ class ChatService(BaseService):
                     chat_response_message=chat_response.message,
                 ):
                     yield chunk
+
+            # Stream the chat response message object. We don't include the message content in the response.
+            yield ChatStreamResponse(
+                event=ChatMessageStreamEvent.STREAM_COMPLETE,
+                content=ChatMessageResponse.model_validate(chat_response).model_dump(
+                    mode="json", exclude={"message"}
+                ),
+            ).as_json()
 
         except Exception as e:
             logger.error(f"Error handling new chat message: {e}")
@@ -794,9 +794,6 @@ class ChatService(BaseService):
                 user_id=user_id,
             ):
                 yield chunk
-
-            # End stream
-            yield ChatStreamResponse(event=ChatMessageStreamEvent.END, content="").as_json()
 
     def create_chat_feedback(
         self, chat_feedback_request: ChatFeedbackRequest

--- a/chatbot-core/backend/app/settings/constants.py
+++ b/chatbot-core/backend/app/settings/constants.py
@@ -119,6 +119,82 @@ class Constants:
     CELERY_WORKER_POOL = "threads"
     CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
+    # LLM Prompts
+    CHAT_SESSION_NAMING_PROMPT = """
+    Generate a short and concise title (5-10 words) for the chat session based on the following conversation:
+
+    User: {user_message}
+    Agent: {agent_message}
+
+    Provide answer without double quotes.
+    """
+
+    CHAT_ENGINE_SYSTEM_PROMPT = """
+    You are a human resources professional at a company that needs to quickly find information in its policy documents.
+
+    Guidelines:
+    - Provide information explicitly stated in policy documents
+    - For basic contextual questions (company name, policy type, etc), use ONLY information directly visible in the provided context
+    - No assumptions or interpretations about policy details
+    - Do not explain
+    - Your primary language is Vietnamese
+    - If you cannot find an answer, please output "Không tìm thấy thông tin, hãy liên hệ HR. SĐT: 0919 397 169 (Ms. Nhã) hoặc email hr@giaiphaptinhhoa.com"
+    - If the response is empty, please answer with the knowledge you have
+
+    Let's work this out in a step by step way to be sure we have the right answer.
+    Answer as the tone of a human resources professional, be polite and helpful."""
+
+    CHAT_ENGINE_CONTEXT_PROMPT = """
+    The following is a friendly conversation between an employee and a human resources professional.
+    The professional is talkative and provides lots of specific details from her context.
+    If the professional does not know the answer to a question, she truthfully says she does not know.
+
+    Here are the relevant documents for the context:
+    '''
+    {context_str}
+    '''
+
+    ## Instruction
+    Based on the above documents, provide a detailed answer for the employee question below.
+    Answer "don't know" if not present in the document."""
+
+    CHAT_ENGINE_CONTEXT_REFINE_PROMPT = """
+    The following is a friendly conversation between an employee and a human resources professional.
+    The professional is talkative and provides lots of specific details from her context.
+    If the professional does not know the answer to a question, she truthfully says she does not know.
+
+    Here are the relevant documents for the context:
+    '''
+    {context_msg}
+    '''
+
+    Existing Answer:
+    '''
+    {existing_answer}
+    '''
+
+    ## Instruction
+    Refine the existing answer using the provided context to assist the user.
+    If the context isn't helpful, just repeat the existing answer and nothing more."""
+
+    CHAT_ENGINE_CONDENSE_PROMPT = """
+    Given the following conversation between an employee and a human resources professional and a follow up question from the employee.
+    Your task is to firstly summarize the chat history and secondly condense the follow up question into a standalone question.
+
+    Chat History:
+    '''
+    {chat_history}
+    '''
+
+    Follow Up Input:
+    '''
+    {question}
+    '''
+
+    Output format: a standalone question.
+
+    Your response:"""
+
 
 class CeleryPriority(int, Enum):
     HIGHEST = 0

--- a/chatbot-core/backend/app/settings/secrets.py
+++ b/chatbot-core/backend/app/settings/secrets.py
@@ -18,11 +18,11 @@ class Secrets:
     MINIO_SECRET_KEY = os.getenv("MINIO_ROOT_PASSWORD", "P&ssword123")
 
     # Qdrant Credentials
-    QDRANT_HOST = os.getenv("QDRANT_HOST", "localhost")
+    QDRANT_HOST = os.getenv("QDRANT_HOST", "127.0.0.1")
     QDRANT_PORT = int(os.getenv("QDRANT_PORT", 6333))
 
     # Redis Credentials
-    REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+    REDIS_HOST = os.getenv("REDIS_HOST", "127.0.0.1")
     REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 
     # Ferment API Key

--- a/deployment/docker_compose/docker-compose.dev.yaml
+++ b/deployment/docker_compose/docker-compose.dev.yaml
@@ -255,6 +255,8 @@ volumes:
 networks:
   chatbot-core:
     driver: bridge
+    driver_opts:
+      com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"
 
 configs:
   qdrant_config:


### PR DESCRIPTION
**Context**: Currently, chat sessions are displayed using UUIDs, making them difficult for users to identify. The frontend and backend teams need to implement a more user-friendly naming system.

**Solution**: If we are on the entire new chat session, provide the LLM context of the user message and the agent response, receive the concise title (5-10 words) for the chat session.