### PR TITLE
ci(dbdocs): fix not running workflow

### DIFF
--- a/.github/workflows/dbdocs.yml
+++ b/.github/workflows/dbdocs.yml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Update dbdocs project
         env:
-          DBDOCS_TOKEN: ${{ secrets.dbdocs_token.DBDOCS_TOKEN }}
+          DBDOCS_TOKEN: ${{ secrets.DBDOCS_TOKEN }}
         run: dbdocs build chatbot-core/EzHR-Chatbot.dbml

--- a/.github/workflows/dbdocs.yml
+++ b/.github/workflows/dbdocs.yml
@@ -6,6 +6,8 @@ on:
       - "chatbot-core/EzHR-Chatbot.dbml"
     branches: [main]
 
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dbdocs
-        run: sudo npm install -g dbdocs
+        run: npm install -g dbdocs
 
       - name: Check dbdocs
         run: dbdocs


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
The action that deploys to dbdocs.io are not triggered. This PR is to fix it by fixing the secret from this repository.

Also, add a manually trigger command. Can find it in the 'Action' on GitHub web.

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->
Example passed workflow: https://github.com/TinhHoaSolutions-EzHR/chatbot/actions/runs/13094963444

## Accepted Risk

<!-- Any know risks or failure modes to point out to reviewers -->

## Related Issue(s)

<!-- If applicable, link to the issue(s) this PR addresses -->

## Checklist:

- [x] Author has done a final read through of the PR right before merge
- [x] All tests passed
- [ ] Code review
- [x] (Optional) If there are migrations, they have been rebased to latest main
- [x] (Optional) If there are new dependencies, they are added to the requirements
- [x] (Optional) If there are new environment variables, they are added to all of the deployment methods
- [x] (Optional) Docker images build and basic functionalities work
